### PR TITLE
Handle SQL strings containing escaped quotes

### DIFF
--- a/lyx/lexer.go
+++ b/lyx/lexer.go
@@ -1,2085 +1,3863 @@
-
 //line lyx/lexer.rl:1
 package lyx
 
 import (
-    "strconv"
+	"strconv"
+	"strings"
 )
 
+const escapedQuotePlaceholder byte = '\a'
 
-//line lyx/lexer.go:11
+//line lyx/lexer.go:13
 const lexer_start int = 9
 const lexer_first_final int = 9
 const lexer_error int = 0
 
 const lexer_en_main int = 9
 
-
 //line lyx/lexer.rl:13
 
-
 type Lexer struct {
-	data         []byte
-	p, pe, cs    int
-	ts, te, act  int
+	data        []byte
+	p, pe, cs   int
+	ts, te, act int
 
-	result []string
+	result                     []string
+	hasEscapedQuotePlaceholder bool
 }
 
 func NewLexer(data []byte) *Lexer {
-    lex := &Lexer{ 
-        data: data,
-        pe: len(data),
-    }
-    
+	buf, changed := normalizeEscapedQuotes(data)
+	lex := &Lexer{
+		data:                       buf,
+		pe:                         len(buf),
+		hasEscapedQuotePlaceholder: changed,
+	}
+
 //line lyx/lexer.go:36
 	{
-	 lex.cs = lexer_start
-	 lex.ts = 0
-	 lex.te = 0
-	 lex.act = 0
+		lex.cs = lexer_start
+		lex.ts = 0
+		lex.te = 0
+		lex.act = 0
 	}
 
 //line lyx/lexer.rl:29
-    return lex
+	return lex
 }
 
 func ResetLexer(lex *Lexer, data []byte) {
-    lex.pe = len(data)
-    lex.data = data
-    
+	buf, changed := normalizeEscapedQuotes(data)
+	lex.data = buf
+	lex.pe = len(buf)
+	lex.hasEscapedQuotePlaceholder = changed
+
 //line lyx/lexer.go:52
 	{
-	 lex.cs = lexer_start
-	 lex.ts = 0
-	 lex.te = 0
-	 lex.act = 0
+		lex.cs = lexer_start
+		lex.ts = 0
+		lex.te = 0
+		lex.act = 0
 	}
 
 //line lyx/lexer.rl:36
+}
+
+func normalizeEscapedQuotes(data []byte) ([]byte, bool) {
+	var normalized []byte
+	inString := false
+
+	for i := 0; i < len(data); {
+		ch := data[i]
+		if ch == '\'' {
+			if inString {
+				if i+1 < len(data) && data[i+1] == '\'' {
+					if normalized == nil {
+						normalized = append(normalized, data[:i]...)
+					}
+					normalized = append(normalized, escapedQuotePlaceholder)
+					i += 2
+					continue
+				}
+				inString = false
+			} else {
+				inString = true
+			}
+		}
+
+		if normalized != nil {
+			normalized = append(normalized, ch)
+		}
+
+		i++
+	}
+
+	if normalized == nil {
+		return data, false
+	}
+
+	return normalized, true
+}
+
+func restoreEscapedQuotes(val string) string {
+	if !strings.ContainsRune(val, rune(escapedQuotePlaceholder)) {
+		return val
+	}
+
+	return strings.ReplaceAll(val, string(escapedQuotePlaceholder), "'")
 }
 
 func (l *Lexer) Error(msg string) {
 	println(msg)
 }
 
-
 func (lex *Lexer) Lex(lval *yySymType) int {
-    eof := lex.pe
-    var tok int
+	eof := lex.pe
+	var tok int
 
-    
 //line lyx/lexer.go:73
 	{
-	if ( lex.p) == ( lex.pe) {
-		goto _test_eof
-	}
-	switch  lex.cs {
-	case 9:
-		goto st_case_9
-	case 0:
-		goto st_case_0
-	case 10:
-		goto st_case_10
-	case 11:
-		goto st_case_11
-	case 12:
-		goto st_case_12
-	case 1:
-		goto st_case_1
-	case 2:
-		goto st_case_2
-	case 3:
-		goto st_case_3
-	case 13:
-		goto st_case_13
-	case 4:
-		goto st_case_4
-	case 14:
-		goto st_case_14
-	case 15:
-		goto st_case_15
-	case 16:
-		goto st_case_16
-	case 5:
-		goto st_case_5
-	case 17:
-		goto st_case_17
-	case 18:
-		goto st_case_18
-	case 6:
-		goto st_case_6
-	case 7:
-		goto st_case_7
-	case 8:
-		goto st_case_8
-	case 19:
-		goto st_case_19
-	case 20:
-		goto st_case_20
-	case 21:
-		goto st_case_21
-	case 22:
-		goto st_case_22
-	case 23:
-		goto st_case_23
-	case 24:
-		goto st_case_24
-	case 25:
-		goto st_case_25
-	case 26:
-		goto st_case_26
-	case 27:
-		goto st_case_27
-	case 28:
-		goto st_case_28
-	case 29:
-		goto st_case_29
-	case 30:
-		goto st_case_30
-	case 31:
-		goto st_case_31
-	case 32:
-		goto st_case_32
-	case 33:
-		goto st_case_33
-	case 34:
-		goto st_case_34
-	case 35:
-		goto st_case_35
-	case 36:
-		goto st_case_36
-	case 37:
-		goto st_case_37
-	case 38:
-		goto st_case_38
-	case 39:
-		goto st_case_39
-	case 40:
-		goto st_case_40
-	case 41:
-		goto st_case_41
-	case 42:
-		goto st_case_42
-	case 43:
-		goto st_case_43
-	case 44:
-		goto st_case_44
-	case 45:
-		goto st_case_45
-	case 46:
-		goto st_case_46
-	case 47:
-		goto st_case_47
-	case 48:
-		goto st_case_48
-	case 49:
-		goto st_case_49
-	case 50:
-		goto st_case_50
-	case 51:
-		goto st_case_51
-	case 52:
-		goto st_case_52
-	case 53:
-		goto st_case_53
-	case 54:
-		goto st_case_54
-	case 55:
-		goto st_case_55
-	case 56:
-		goto st_case_56
-	case 57:
-		goto st_case_57
-	case 58:
-		goto st_case_58
-	case 59:
-		goto st_case_59
-	case 60:
-		goto st_case_60
-	case 61:
-		goto st_case_61
-	case 62:
-		goto st_case_62
-	case 63:
-		goto st_case_63
-	case 64:
-		goto st_case_64
-	case 65:
-		goto st_case_65
-	case 66:
-		goto st_case_66
-	case 67:
-		goto st_case_67
-	case 68:
-		goto st_case_68
-	case 69:
-		goto st_case_69
-	case 70:
-		goto st_case_70
-	case 71:
-		goto st_case_71
-	case 72:
-		goto st_case_72
-	case 73:
-		goto st_case_73
-	case 74:
-		goto st_case_74
-	case 75:
-		goto st_case_75
-	case 76:
-		goto st_case_76
-	case 77:
-		goto st_case_77
-	case 78:
-		goto st_case_78
-	case 79:
-		goto st_case_79
-	case 80:
-		goto st_case_80
-	case 81:
-		goto st_case_81
-	case 82:
-		goto st_case_82
-	case 83:
-		goto st_case_83
-	case 84:
-		goto st_case_84
-	case 85:
-		goto st_case_85
-	case 86:
-		goto st_case_86
-	case 87:
-		goto st_case_87
-	case 88:
-		goto st_case_88
-	case 89:
-		goto st_case_89
-	case 90:
-		goto st_case_90
-	case 91:
-		goto st_case_91
-	case 92:
-		goto st_case_92
-	case 93:
-		goto st_case_93
-	case 94:
-		goto st_case_94
-	case 95:
-		goto st_case_95
-	case 96:
-		goto st_case_96
-	case 97:
-		goto st_case_97
-	case 98:
-		goto st_case_98
-	case 99:
-		goto st_case_99
-	case 100:
-		goto st_case_100
-	case 101:
-		goto st_case_101
-	case 102:
-		goto st_case_102
-	case 103:
-		goto st_case_103
-	case 104:
-		goto st_case_104
-	case 105:
-		goto st_case_105
-	case 106:
-		goto st_case_106
-	case 107:
-		goto st_case_107
-	case 108:
-		goto st_case_108
-	case 109:
-		goto st_case_109
-	case 110:
-		goto st_case_110
-	case 111:
-		goto st_case_111
-	case 112:
-		goto st_case_112
-	case 113:
-		goto st_case_113
-	case 114:
-		goto st_case_114
-	case 115:
-		goto st_case_115
-	case 116:
-		goto st_case_116
-	case 117:
-		goto st_case_117
-	case 118:
-		goto st_case_118
-	case 119:
-		goto st_case_119
-	case 120:
-		goto st_case_120
-	case 121:
-		goto st_case_121
-	case 122:
-		goto st_case_122
-	case 123:
-		goto st_case_123
-	case 124:
-		goto st_case_124
-	case 125:
-		goto st_case_125
-	case 126:
-		goto st_case_126
-	case 127:
-		goto st_case_127
-	case 128:
-		goto st_case_128
-	case 129:
-		goto st_case_129
-	case 130:
-		goto st_case_130
-	case 131:
-		goto st_case_131
-	case 132:
-		goto st_case_132
-	case 133:
-		goto st_case_133
-	case 134:
-		goto st_case_134
-	case 135:
-		goto st_case_135
-	case 136:
-		goto st_case_136
-	case 137:
-		goto st_case_137
-	case 138:
-		goto st_case_138
-	case 139:
-		goto st_case_139
-	case 140:
-		goto st_case_140
-	case 141:
-		goto st_case_141
-	case 142:
-		goto st_case_142
-	case 143:
-		goto st_case_143
-	case 144:
-		goto st_case_144
-	case 145:
-		goto st_case_145
-	case 146:
-		goto st_case_146
-	case 147:
-		goto st_case_147
-	case 148:
-		goto st_case_148
-	case 149:
-		goto st_case_149
-	case 150:
-		goto st_case_150
-	case 151:
-		goto st_case_151
-	case 152:
-		goto st_case_152
-	case 153:
-		goto st_case_153
-	case 154:
-		goto st_case_154
-	case 155:
-		goto st_case_155
-	case 156:
-		goto st_case_156
-	case 157:
-		goto st_case_157
-	case 158:
-		goto st_case_158
-	case 159:
-		goto st_case_159
-	case 160:
-		goto st_case_160
-	case 161:
-		goto st_case_161
-	case 162:
-		goto st_case_162
-	case 163:
-		goto st_case_163
-	case 164:
-		goto st_case_164
-	case 165:
-		goto st_case_165
-	case 166:
-		goto st_case_166
-	case 167:
-		goto st_case_167
-	case 168:
-		goto st_case_168
-	case 169:
-		goto st_case_169
-	case 170:
-		goto st_case_170
-	case 171:
-		goto st_case_171
-	case 172:
-		goto st_case_172
-	case 173:
-		goto st_case_173
-	case 174:
-		goto st_case_174
-	case 175:
-		goto st_case_175
-	case 176:
-		goto st_case_176
-	case 177:
-		goto st_case_177
-	case 178:
-		goto st_case_178
-	case 179:
-		goto st_case_179
-	case 180:
-		goto st_case_180
-	case 181:
-		goto st_case_181
-	case 182:
-		goto st_case_182
-	case 183:
-		goto st_case_183
-	case 184:
-		goto st_case_184
-	case 185:
-		goto st_case_185
-	case 186:
-		goto st_case_186
-	case 187:
-		goto st_case_187
-	case 188:
-		goto st_case_188
-	case 189:
-		goto st_case_189
-	case 190:
-		goto st_case_190
-	case 191:
-		goto st_case_191
-	case 192:
-		goto st_case_192
-	case 193:
-		goto st_case_193
-	case 194:
-		goto st_case_194
-	case 195:
-		goto st_case_195
-	case 196:
-		goto st_case_196
-	case 197:
-		goto st_case_197
-	case 198:
-		goto st_case_198
-	case 199:
-		goto st_case_199
-	case 200:
-		goto st_case_200
-	case 201:
-		goto st_case_201
-	case 202:
-		goto st_case_202
-	case 203:
-		goto st_case_203
-	case 204:
-		goto st_case_204
-	case 205:
-		goto st_case_205
-	case 206:
-		goto st_case_206
-	case 207:
-		goto st_case_207
-	case 208:
-		goto st_case_208
-	case 209:
-		goto st_case_209
-	case 210:
-		goto st_case_210
-	case 211:
-		goto st_case_211
-	case 212:
-		goto st_case_212
-	case 213:
-		goto st_case_213
-	case 214:
-		goto st_case_214
-	case 215:
-		goto st_case_215
-	case 216:
-		goto st_case_216
-	case 217:
-		goto st_case_217
-	case 218:
-		goto st_case_218
-	case 219:
-		goto st_case_219
-	case 220:
-		goto st_case_220
-	case 221:
-		goto st_case_221
-	case 222:
-		goto st_case_222
-	case 223:
-		goto st_case_223
-	case 224:
-		goto st_case_224
-	case 225:
-		goto st_case_225
-	case 226:
-		goto st_case_226
-	case 227:
-		goto st_case_227
-	case 228:
-		goto st_case_228
-	case 229:
-		goto st_case_229
-	case 230:
-		goto st_case_230
-	case 231:
-		goto st_case_231
-	case 232:
-		goto st_case_232
-	case 233:
-		goto st_case_233
-	case 234:
-		goto st_case_234
-	case 235:
-		goto st_case_235
-	case 236:
-		goto st_case_236
-	case 237:
-		goto st_case_237
-	case 238:
-		goto st_case_238
-	case 239:
-		goto st_case_239
-	case 240:
-		goto st_case_240
-	case 241:
-		goto st_case_241
-	case 242:
-		goto st_case_242
-	case 243:
-		goto st_case_243
-	case 244:
-		goto st_case_244
-	case 245:
-		goto st_case_245
-	case 246:
-		goto st_case_246
-	case 247:
-		goto st_case_247
-	case 248:
-		goto st_case_248
-	case 249:
-		goto st_case_249
-	case 250:
-		goto st_case_250
-	case 251:
-		goto st_case_251
-	case 252:
-		goto st_case_252
-	case 253:
-		goto st_case_253
-	case 254:
-		goto st_case_254
-	case 255:
-		goto st_case_255
-	case 256:
-		goto st_case_256
-	case 257:
-		goto st_case_257
-	case 258:
-		goto st_case_258
-	case 259:
-		goto st_case_259
-	case 260:
-		goto st_case_260
-	case 261:
-		goto st_case_261
-	case 262:
-		goto st_case_262
-	case 263:
-		goto st_case_263
-	case 264:
-		goto st_case_264
-	case 265:
-		goto st_case_265
-	case 266:
-		goto st_case_266
-	case 267:
-		goto st_case_267
-	case 268:
-		goto st_case_268
-	case 269:
-		goto st_case_269
-	case 270:
-		goto st_case_270
-	case 271:
-		goto st_case_271
-	case 272:
-		goto st_case_272
-	case 273:
-		goto st_case_273
-	case 274:
-		goto st_case_274
-	case 275:
-		goto st_case_275
-	case 276:
-		goto st_case_276
-	case 277:
-		goto st_case_277
-	case 278:
-		goto st_case_278
-	case 279:
-		goto st_case_279
-	case 280:
-		goto st_case_280
-	case 281:
-		goto st_case_281
-	case 282:
-		goto st_case_282
-	case 283:
-		goto st_case_283
-	case 284:
-		goto st_case_284
-	case 285:
-		goto st_case_285
-	case 286:
-		goto st_case_286
-	case 287:
-		goto st_case_287
-	case 288:
-		goto st_case_288
-	case 289:
-		goto st_case_289
-	case 290:
-		goto st_case_290
-	case 291:
-		goto st_case_291
-	case 292:
-		goto st_case_292
-	case 293:
-		goto st_case_293
-	case 294:
-		goto st_case_294
-	case 295:
-		goto st_case_295
-	case 296:
-		goto st_case_296
-	case 297:
-		goto st_case_297
-	case 298:
-		goto st_case_298
-	case 299:
-		goto st_case_299
-	case 300:
-		goto st_case_300
-	case 301:
-		goto st_case_301
-	case 302:
-		goto st_case_302
-	case 303:
-		goto st_case_303
-	case 304:
-		goto st_case_304
-	case 305:
-		goto st_case_305
-	case 306:
-		goto st_case_306
-	case 307:
-		goto st_case_307
-	case 308:
-		goto st_case_308
-	case 309:
-		goto st_case_309
-	case 310:
-		goto st_case_310
-	case 311:
-		goto st_case_311
-	case 312:
-		goto st_case_312
-	case 313:
-		goto st_case_313
-	case 314:
-		goto st_case_314
-	case 315:
-		goto st_case_315
-	case 316:
-		goto st_case_316
-	case 317:
-		goto st_case_317
-	case 318:
-		goto st_case_318
-	case 319:
-		goto st_case_319
-	case 320:
-		goto st_case_320
-	case 321:
-		goto st_case_321
-	case 322:
-		goto st_case_322
-	case 323:
-		goto st_case_323
-	case 324:
-		goto st_case_324
-	case 325:
-		goto st_case_325
-	case 326:
-		goto st_case_326
-	case 327:
-		goto st_case_327
-	case 328:
-		goto st_case_328
-	case 329:
-		goto st_case_329
-	case 330:
-		goto st_case_330
-	case 331:
-		goto st_case_331
-	case 332:
-		goto st_case_332
-	case 333:
-		goto st_case_333
-	case 334:
-		goto st_case_334
-	case 335:
-		goto st_case_335
-	case 336:
-		goto st_case_336
-	case 337:
-		goto st_case_337
-	case 338:
-		goto st_case_338
-	case 339:
-		goto st_case_339
-	case 340:
-		goto st_case_340
-	case 341:
-		goto st_case_341
-	case 342:
-		goto st_case_342
-	case 343:
-		goto st_case_343
-	case 344:
-		goto st_case_344
-	case 345:
-		goto st_case_345
-	case 346:
-		goto st_case_346
-	case 347:
-		goto st_case_347
-	case 348:
-		goto st_case_348
-	case 349:
-		goto st_case_349
-	case 350:
-		goto st_case_350
-	case 351:
-		goto st_case_351
-	case 352:
-		goto st_case_352
-	case 353:
-		goto st_case_353
-	case 354:
-		goto st_case_354
-	case 355:
-		goto st_case_355
-	case 356:
-		goto st_case_356
-	case 357:
-		goto st_case_357
-	case 358:
-		goto st_case_358
-	case 359:
-		goto st_case_359
-	case 360:
-		goto st_case_360
-	case 361:
-		goto st_case_361
-	case 362:
-		goto st_case_362
-	case 363:
-		goto st_case_363
-	case 364:
-		goto st_case_364
-	case 365:
-		goto st_case_365
-	case 366:
-		goto st_case_366
-	case 367:
-		goto st_case_367
-	case 368:
-		goto st_case_368
-	case 369:
-		goto st_case_369
-	case 370:
-		goto st_case_370
-	case 371:
-		goto st_case_371
-	case 372:
-		goto st_case_372
-	case 373:
-		goto st_case_373
-	case 374:
-		goto st_case_374
-	case 375:
-		goto st_case_375
-	case 376:
-		goto st_case_376
-	case 377:
-		goto st_case_377
-	case 378:
-		goto st_case_378
-	case 379:
-		goto st_case_379
-	case 380:
-		goto st_case_380
-	case 381:
-		goto st_case_381
-	case 382:
-		goto st_case_382
-	case 383:
-		goto st_case_383
-	case 384:
-		goto st_case_384
-	case 385:
-		goto st_case_385
-	case 386:
-		goto st_case_386
-	case 387:
-		goto st_case_387
-	case 388:
-		goto st_case_388
-	case 389:
-		goto st_case_389
-	case 390:
-		goto st_case_390
-	case 391:
-		goto st_case_391
-	case 392:
-		goto st_case_392
-	case 393:
-		goto st_case_393
-	case 394:
-		goto st_case_394
-	case 395:
-		goto st_case_395
-	case 396:
-		goto st_case_396
-	case 397:
-		goto st_case_397
-	case 398:
-		goto st_case_398
-	case 399:
-		goto st_case_399
-	case 400:
-		goto st_case_400
-	case 401:
-		goto st_case_401
-	case 402:
-		goto st_case_402
-	case 403:
-		goto st_case_403
-	case 404:
-		goto st_case_404
-	case 405:
-		goto st_case_405
-	case 406:
-		goto st_case_406
-	case 407:
-		goto st_case_407
-	case 408:
-		goto st_case_408
-	case 409:
-		goto st_case_409
-	case 410:
-		goto st_case_410
-	case 411:
-		goto st_case_411
-	case 412:
-		goto st_case_412
-	case 413:
-		goto st_case_413
-	case 414:
-		goto st_case_414
-	case 415:
-		goto st_case_415
-	case 416:
-		goto st_case_416
-	case 417:
-		goto st_case_417
-	case 418:
-		goto st_case_418
-	case 419:
-		goto st_case_419
-	case 420:
-		goto st_case_420
-	case 421:
-		goto st_case_421
-	case 422:
-		goto st_case_422
-	case 423:
-		goto st_case_423
-	case 424:
-		goto st_case_424
-	case 425:
-		goto st_case_425
-	case 426:
-		goto st_case_426
-	case 427:
-		goto st_case_427
-	case 428:
-		goto st_case_428
-	case 429:
-		goto st_case_429
-	case 430:
-		goto st_case_430
-	case 431:
-		goto st_case_431
-	case 432:
-		goto st_case_432
-	case 433:
-		goto st_case_433
-	case 434:
-		goto st_case_434
-	case 435:
-		goto st_case_435
-	case 436:
-		goto st_case_436
-	case 437:
-		goto st_case_437
-	case 438:
-		goto st_case_438
-	case 439:
-		goto st_case_439
-	case 440:
-		goto st_case_440
-	case 441:
-		goto st_case_441
-	case 442:
-		goto st_case_442
-	case 443:
-		goto st_case_443
-	case 444:
-		goto st_case_444
-	case 445:
-		goto st_case_445
-	case 446:
-		goto st_case_446
-	case 447:
-		goto st_case_447
-	case 448:
-		goto st_case_448
-	case 449:
-		goto st_case_449
-	case 450:
-		goto st_case_450
-	case 451:
-		goto st_case_451
-	case 452:
-		goto st_case_452
-	case 453:
-		goto st_case_453
-	case 454:
-		goto st_case_454
-	case 455:
-		goto st_case_455
-	case 456:
-		goto st_case_456
-	case 457:
-		goto st_case_457
-	case 458:
-		goto st_case_458
-	case 459:
-		goto st_case_459
-	case 460:
-		goto st_case_460
-	case 461:
-		goto st_case_461
-	case 462:
-		goto st_case_462
-	case 463:
-		goto st_case_463
-	case 464:
-		goto st_case_464
-	case 465:
-		goto st_case_465
-	case 466:
-		goto st_case_466
-	case 467:
-		goto st_case_467
-	case 468:
-		goto st_case_468
-	case 469:
-		goto st_case_469
-	case 470:
-		goto st_case_470
-	case 471:
-		goto st_case_471
-	case 472:
-		goto st_case_472
-	case 473:
-		goto st_case_473
-	case 474:
-		goto st_case_474
-	case 475:
-		goto st_case_475
-	case 476:
-		goto st_case_476
-	case 477:
-		goto st_case_477
-	case 478:
-		goto st_case_478
-	case 479:
-		goto st_case_479
-	case 480:
-		goto st_case_480
-	case 481:
-		goto st_case_481
-	case 482:
-		goto st_case_482
-	case 483:
-		goto st_case_483
-	case 484:
-		goto st_case_484
-	case 485:
-		goto st_case_485
-	case 486:
-		goto st_case_486
-	case 487:
-		goto st_case_487
-	case 488:
-		goto st_case_488
-	case 489:
-		goto st_case_489
-	case 490:
-		goto st_case_490
-	case 491:
-		goto st_case_491
-	case 492:
-		goto st_case_492
-	case 493:
-		goto st_case_493
-	case 494:
-		goto st_case_494
-	case 495:
-		goto st_case_495
-	case 496:
-		goto st_case_496
-	case 497:
-		goto st_case_497
-	case 498:
-		goto st_case_498
-	case 499:
-		goto st_case_499
-	case 500:
-		goto st_case_500
-	case 501:
-		goto st_case_501
-	case 502:
-		goto st_case_502
-	case 503:
-		goto st_case_503
-	case 504:
-		goto st_case_504
-	case 505:
-		goto st_case_505
-	case 506:
-		goto st_case_506
-	case 507:
-		goto st_case_507
-	case 508:
-		goto st_case_508
-	case 509:
-		goto st_case_509
-	case 510:
-		goto st_case_510
-	case 511:
-		goto st_case_511
-	case 512:
-		goto st_case_512
-	case 513:
-		goto st_case_513
-	case 514:
-		goto st_case_514
-	case 515:
-		goto st_case_515
-	case 516:
-		goto st_case_516
-	case 517:
-		goto st_case_517
-	case 518:
-		goto st_case_518
-	case 519:
-		goto st_case_519
-	case 520:
-		goto st_case_520
-	case 521:
-		goto st_case_521
-	case 522:
-		goto st_case_522
-	case 523:
-		goto st_case_523
-	case 524:
-		goto st_case_524
-	case 525:
-		goto st_case_525
-	case 526:
-		goto st_case_526
-	case 527:
-		goto st_case_527
-	case 528:
-		goto st_case_528
-	case 529:
-		goto st_case_529
-	case 530:
-		goto st_case_530
-	case 531:
-		goto st_case_531
-	case 532:
-		goto st_case_532
-	case 533:
-		goto st_case_533
-	case 534:
-		goto st_case_534
-	case 535:
-		goto st_case_535
-	case 536:
-		goto st_case_536
-	case 537:
-		goto st_case_537
-	case 538:
-		goto st_case_538
-	case 539:
-		goto st_case_539
-	case 540:
-		goto st_case_540
-	case 541:
-		goto st_case_541
-	case 542:
-		goto st_case_542
-	case 543:
-		goto st_case_543
-	case 544:
-		goto st_case_544
-	case 545:
-		goto st_case_545
-	case 546:
-		goto st_case_546
-	case 547:
-		goto st_case_547
-	case 548:
-		goto st_case_548
-	case 549:
-		goto st_case_549
-	case 550:
-		goto st_case_550
-	case 551:
-		goto st_case_551
-	case 552:
-		goto st_case_552
-	case 553:
-		goto st_case_553
-	case 554:
-		goto st_case_554
-	case 555:
-		goto st_case_555
-	case 556:
-		goto st_case_556
-	case 557:
-		goto st_case_557
-	case 558:
-		goto st_case_558
-	case 559:
-		goto st_case_559
-	case 560:
-		goto st_case_560
-	case 561:
-		goto st_case_561
-	case 562:
-		goto st_case_562
-	case 563:
-		goto st_case_563
-	case 564:
-		goto st_case_564
-	case 565:
-		goto st_case_565
-	case 566:
-		goto st_case_566
-	case 567:
-		goto st_case_567
-	case 568:
-		goto st_case_568
-	case 569:
-		goto st_case_569
-	case 570:
-		goto st_case_570
-	case 571:
-		goto st_case_571
-	case 572:
-		goto st_case_572
-	case 573:
-		goto st_case_573
-	case 574:
-		goto st_case_574
-	case 575:
-		goto st_case_575
-	case 576:
-		goto st_case_576
-	case 577:
-		goto st_case_577
-	case 578:
-		goto st_case_578
-	case 579:
-		goto st_case_579
-	case 580:
-		goto st_case_580
-	case 581:
-		goto st_case_581
-	case 582:
-		goto st_case_582
-	case 583:
-		goto st_case_583
-	case 584:
-		goto st_case_584
-	case 585:
-		goto st_case_585
-	case 586:
-		goto st_case_586
-	case 587:
-		goto st_case_587
-	case 588:
-		goto st_case_588
-	case 589:
-		goto st_case_589
-	case 590:
-		goto st_case_590
-	case 591:
-		goto st_case_591
-	case 592:
-		goto st_case_592
-	case 593:
-		goto st_case_593
-	case 594:
-		goto st_case_594
-	case 595:
-		goto st_case_595
-	case 596:
-		goto st_case_596
-	}
-	goto st_out
-tr0:
+		if (lex.p) == (lex.pe) {
+			goto _test_eof
+		}
+		switch lex.cs {
+		case 9:
+			goto st_case_9
+		case 0:
+			goto st_case_0
+		case 10:
+			goto st_case_10
+		case 11:
+			goto st_case_11
+		case 12:
+			goto st_case_12
+		case 1:
+			goto st_case_1
+		case 2:
+			goto st_case_2
+		case 3:
+			goto st_case_3
+		case 13:
+			goto st_case_13
+		case 4:
+			goto st_case_4
+		case 14:
+			goto st_case_14
+		case 15:
+			goto st_case_15
+		case 16:
+			goto st_case_16
+		case 5:
+			goto st_case_5
+		case 17:
+			goto st_case_17
+		case 18:
+			goto st_case_18
+		case 6:
+			goto st_case_6
+		case 7:
+			goto st_case_7
+		case 8:
+			goto st_case_8
+		case 19:
+			goto st_case_19
+		case 20:
+			goto st_case_20
+		case 21:
+			goto st_case_21
+		case 22:
+			goto st_case_22
+		case 23:
+			goto st_case_23
+		case 24:
+			goto st_case_24
+		case 25:
+			goto st_case_25
+		case 26:
+			goto st_case_26
+		case 27:
+			goto st_case_27
+		case 28:
+			goto st_case_28
+		case 29:
+			goto st_case_29
+		case 30:
+			goto st_case_30
+		case 31:
+			goto st_case_31
+		case 32:
+			goto st_case_32
+		case 33:
+			goto st_case_33
+		case 34:
+			goto st_case_34
+		case 35:
+			goto st_case_35
+		case 36:
+			goto st_case_36
+		case 37:
+			goto st_case_37
+		case 38:
+			goto st_case_38
+		case 39:
+			goto st_case_39
+		case 40:
+			goto st_case_40
+		case 41:
+			goto st_case_41
+		case 42:
+			goto st_case_42
+		case 43:
+			goto st_case_43
+		case 44:
+			goto st_case_44
+		case 45:
+			goto st_case_45
+		case 46:
+			goto st_case_46
+		case 47:
+			goto st_case_47
+		case 48:
+			goto st_case_48
+		case 49:
+			goto st_case_49
+		case 50:
+			goto st_case_50
+		case 51:
+			goto st_case_51
+		case 52:
+			goto st_case_52
+		case 53:
+			goto st_case_53
+		case 54:
+			goto st_case_54
+		case 55:
+			goto st_case_55
+		case 56:
+			goto st_case_56
+		case 57:
+			goto st_case_57
+		case 58:
+			goto st_case_58
+		case 59:
+			goto st_case_59
+		case 60:
+			goto st_case_60
+		case 61:
+			goto st_case_61
+		case 62:
+			goto st_case_62
+		case 63:
+			goto st_case_63
+		case 64:
+			goto st_case_64
+		case 65:
+			goto st_case_65
+		case 66:
+			goto st_case_66
+		case 67:
+			goto st_case_67
+		case 68:
+			goto st_case_68
+		case 69:
+			goto st_case_69
+		case 70:
+			goto st_case_70
+		case 71:
+			goto st_case_71
+		case 72:
+			goto st_case_72
+		case 73:
+			goto st_case_73
+		case 74:
+			goto st_case_74
+		case 75:
+			goto st_case_75
+		case 76:
+			goto st_case_76
+		case 77:
+			goto st_case_77
+		case 78:
+			goto st_case_78
+		case 79:
+			goto st_case_79
+		case 80:
+			goto st_case_80
+		case 81:
+			goto st_case_81
+		case 82:
+			goto st_case_82
+		case 83:
+			goto st_case_83
+		case 84:
+			goto st_case_84
+		case 85:
+			goto st_case_85
+		case 86:
+			goto st_case_86
+		case 87:
+			goto st_case_87
+		case 88:
+			goto st_case_88
+		case 89:
+			goto st_case_89
+		case 90:
+			goto st_case_90
+		case 91:
+			goto st_case_91
+		case 92:
+			goto st_case_92
+		case 93:
+			goto st_case_93
+		case 94:
+			goto st_case_94
+		case 95:
+			goto st_case_95
+		case 96:
+			goto st_case_96
+		case 97:
+			goto st_case_97
+		case 98:
+			goto st_case_98
+		case 99:
+			goto st_case_99
+		case 100:
+			goto st_case_100
+		case 101:
+			goto st_case_101
+		case 102:
+			goto st_case_102
+		case 103:
+			goto st_case_103
+		case 104:
+			goto st_case_104
+		case 105:
+			goto st_case_105
+		case 106:
+			goto st_case_106
+		case 107:
+			goto st_case_107
+		case 108:
+			goto st_case_108
+		case 109:
+			goto st_case_109
+		case 110:
+			goto st_case_110
+		case 111:
+			goto st_case_111
+		case 112:
+			goto st_case_112
+		case 113:
+			goto st_case_113
+		case 114:
+			goto st_case_114
+		case 115:
+			goto st_case_115
+		case 116:
+			goto st_case_116
+		case 117:
+			goto st_case_117
+		case 118:
+			goto st_case_118
+		case 119:
+			goto st_case_119
+		case 120:
+			goto st_case_120
+		case 121:
+			goto st_case_121
+		case 122:
+			goto st_case_122
+		case 123:
+			goto st_case_123
+		case 124:
+			goto st_case_124
+		case 125:
+			goto st_case_125
+		case 126:
+			goto st_case_126
+		case 127:
+			goto st_case_127
+		case 128:
+			goto st_case_128
+		case 129:
+			goto st_case_129
+		case 130:
+			goto st_case_130
+		case 131:
+			goto st_case_131
+		case 132:
+			goto st_case_132
+		case 133:
+			goto st_case_133
+		case 134:
+			goto st_case_134
+		case 135:
+			goto st_case_135
+		case 136:
+			goto st_case_136
+		case 137:
+			goto st_case_137
+		case 138:
+			goto st_case_138
+		case 139:
+			goto st_case_139
+		case 140:
+			goto st_case_140
+		case 141:
+			goto st_case_141
+		case 142:
+			goto st_case_142
+		case 143:
+			goto st_case_143
+		case 144:
+			goto st_case_144
+		case 145:
+			goto st_case_145
+		case 146:
+			goto st_case_146
+		case 147:
+			goto st_case_147
+		case 148:
+			goto st_case_148
+		case 149:
+			goto st_case_149
+		case 150:
+			goto st_case_150
+		case 151:
+			goto st_case_151
+		case 152:
+			goto st_case_152
+		case 153:
+			goto st_case_153
+		case 154:
+			goto st_case_154
+		case 155:
+			goto st_case_155
+		case 156:
+			goto st_case_156
+		case 157:
+			goto st_case_157
+		case 158:
+			goto st_case_158
+		case 159:
+			goto st_case_159
+		case 160:
+			goto st_case_160
+		case 161:
+			goto st_case_161
+		case 162:
+			goto st_case_162
+		case 163:
+			goto st_case_163
+		case 164:
+			goto st_case_164
+		case 165:
+			goto st_case_165
+		case 166:
+			goto st_case_166
+		case 167:
+			goto st_case_167
+		case 168:
+			goto st_case_168
+		case 169:
+			goto st_case_169
+		case 170:
+			goto st_case_170
+		case 171:
+			goto st_case_171
+		case 172:
+			goto st_case_172
+		case 173:
+			goto st_case_173
+		case 174:
+			goto st_case_174
+		case 175:
+			goto st_case_175
+		case 176:
+			goto st_case_176
+		case 177:
+			goto st_case_177
+		case 178:
+			goto st_case_178
+		case 179:
+			goto st_case_179
+		case 180:
+			goto st_case_180
+		case 181:
+			goto st_case_181
+		case 182:
+			goto st_case_182
+		case 183:
+			goto st_case_183
+		case 184:
+			goto st_case_184
+		case 185:
+			goto st_case_185
+		case 186:
+			goto st_case_186
+		case 187:
+			goto st_case_187
+		case 188:
+			goto st_case_188
+		case 189:
+			goto st_case_189
+		case 190:
+			goto st_case_190
+		case 191:
+			goto st_case_191
+		case 192:
+			goto st_case_192
+		case 193:
+			goto st_case_193
+		case 194:
+			goto st_case_194
+		case 195:
+			goto st_case_195
+		case 196:
+			goto st_case_196
+		case 197:
+			goto st_case_197
+		case 198:
+			goto st_case_198
+		case 199:
+			goto st_case_199
+		case 200:
+			goto st_case_200
+		case 201:
+			goto st_case_201
+		case 202:
+			goto st_case_202
+		case 203:
+			goto st_case_203
+		case 204:
+			goto st_case_204
+		case 205:
+			goto st_case_205
+		case 206:
+			goto st_case_206
+		case 207:
+			goto st_case_207
+		case 208:
+			goto st_case_208
+		case 209:
+			goto st_case_209
+		case 210:
+			goto st_case_210
+		case 211:
+			goto st_case_211
+		case 212:
+			goto st_case_212
+		case 213:
+			goto st_case_213
+		case 214:
+			goto st_case_214
+		case 215:
+			goto st_case_215
+		case 216:
+			goto st_case_216
+		case 217:
+			goto st_case_217
+		case 218:
+			goto st_case_218
+		case 219:
+			goto st_case_219
+		case 220:
+			goto st_case_220
+		case 221:
+			goto st_case_221
+		case 222:
+			goto st_case_222
+		case 223:
+			goto st_case_223
+		case 224:
+			goto st_case_224
+		case 225:
+			goto st_case_225
+		case 226:
+			goto st_case_226
+		case 227:
+			goto st_case_227
+		case 228:
+			goto st_case_228
+		case 229:
+			goto st_case_229
+		case 230:
+			goto st_case_230
+		case 231:
+			goto st_case_231
+		case 232:
+			goto st_case_232
+		case 233:
+			goto st_case_233
+		case 234:
+			goto st_case_234
+		case 235:
+			goto st_case_235
+		case 236:
+			goto st_case_236
+		case 237:
+			goto st_case_237
+		case 238:
+			goto st_case_238
+		case 239:
+			goto st_case_239
+		case 240:
+			goto st_case_240
+		case 241:
+			goto st_case_241
+		case 242:
+			goto st_case_242
+		case 243:
+			goto st_case_243
+		case 244:
+			goto st_case_244
+		case 245:
+			goto st_case_245
+		case 246:
+			goto st_case_246
+		case 247:
+			goto st_case_247
+		case 248:
+			goto st_case_248
+		case 249:
+			goto st_case_249
+		case 250:
+			goto st_case_250
+		case 251:
+			goto st_case_251
+		case 252:
+			goto st_case_252
+		case 253:
+			goto st_case_253
+		case 254:
+			goto st_case_254
+		case 255:
+			goto st_case_255
+		case 256:
+			goto st_case_256
+		case 257:
+			goto st_case_257
+		case 258:
+			goto st_case_258
+		case 259:
+			goto st_case_259
+		case 260:
+			goto st_case_260
+		case 261:
+			goto st_case_261
+		case 262:
+			goto st_case_262
+		case 263:
+			goto st_case_263
+		case 264:
+			goto st_case_264
+		case 265:
+			goto st_case_265
+		case 266:
+			goto st_case_266
+		case 267:
+			goto st_case_267
+		case 268:
+			goto st_case_268
+		case 269:
+			goto st_case_269
+		case 270:
+			goto st_case_270
+		case 271:
+			goto st_case_271
+		case 272:
+			goto st_case_272
+		case 273:
+			goto st_case_273
+		case 274:
+			goto st_case_274
+		case 275:
+			goto st_case_275
+		case 276:
+			goto st_case_276
+		case 277:
+			goto st_case_277
+		case 278:
+			goto st_case_278
+		case 279:
+			goto st_case_279
+		case 280:
+			goto st_case_280
+		case 281:
+			goto st_case_281
+		case 282:
+			goto st_case_282
+		case 283:
+			goto st_case_283
+		case 284:
+			goto st_case_284
+		case 285:
+			goto st_case_285
+		case 286:
+			goto st_case_286
+		case 287:
+			goto st_case_287
+		case 288:
+			goto st_case_288
+		case 289:
+			goto st_case_289
+		case 290:
+			goto st_case_290
+		case 291:
+			goto st_case_291
+		case 292:
+			goto st_case_292
+		case 293:
+			goto st_case_293
+		case 294:
+			goto st_case_294
+		case 295:
+			goto st_case_295
+		case 296:
+			goto st_case_296
+		case 297:
+			goto st_case_297
+		case 298:
+			goto st_case_298
+		case 299:
+			goto st_case_299
+		case 300:
+			goto st_case_300
+		case 301:
+			goto st_case_301
+		case 302:
+			goto st_case_302
+		case 303:
+			goto st_case_303
+		case 304:
+			goto st_case_304
+		case 305:
+			goto st_case_305
+		case 306:
+			goto st_case_306
+		case 307:
+			goto st_case_307
+		case 308:
+			goto st_case_308
+		case 309:
+			goto st_case_309
+		case 310:
+			goto st_case_310
+		case 311:
+			goto st_case_311
+		case 312:
+			goto st_case_312
+		case 313:
+			goto st_case_313
+		case 314:
+			goto st_case_314
+		case 315:
+			goto st_case_315
+		case 316:
+			goto st_case_316
+		case 317:
+			goto st_case_317
+		case 318:
+			goto st_case_318
+		case 319:
+			goto st_case_319
+		case 320:
+			goto st_case_320
+		case 321:
+			goto st_case_321
+		case 322:
+			goto st_case_322
+		case 323:
+			goto st_case_323
+		case 324:
+			goto st_case_324
+		case 325:
+			goto st_case_325
+		case 326:
+			goto st_case_326
+		case 327:
+			goto st_case_327
+		case 328:
+			goto st_case_328
+		case 329:
+			goto st_case_329
+		case 330:
+			goto st_case_330
+		case 331:
+			goto st_case_331
+		case 332:
+			goto st_case_332
+		case 333:
+			goto st_case_333
+		case 334:
+			goto st_case_334
+		case 335:
+			goto st_case_335
+		case 336:
+			goto st_case_336
+		case 337:
+			goto st_case_337
+		case 338:
+			goto st_case_338
+		case 339:
+			goto st_case_339
+		case 340:
+			goto st_case_340
+		case 341:
+			goto st_case_341
+		case 342:
+			goto st_case_342
+		case 343:
+			goto st_case_343
+		case 344:
+			goto st_case_344
+		case 345:
+			goto st_case_345
+		case 346:
+			goto st_case_346
+		case 347:
+			goto st_case_347
+		case 348:
+			goto st_case_348
+		case 349:
+			goto st_case_349
+		case 350:
+			goto st_case_350
+		case 351:
+			goto st_case_351
+		case 352:
+			goto st_case_352
+		case 353:
+			goto st_case_353
+		case 354:
+			goto st_case_354
+		case 355:
+			goto st_case_355
+		case 356:
+			goto st_case_356
+		case 357:
+			goto st_case_357
+		case 358:
+			goto st_case_358
+		case 359:
+			goto st_case_359
+		case 360:
+			goto st_case_360
+		case 361:
+			goto st_case_361
+		case 362:
+			goto st_case_362
+		case 363:
+			goto st_case_363
+		case 364:
+			goto st_case_364
+		case 365:
+			goto st_case_365
+		case 366:
+			goto st_case_366
+		case 367:
+			goto st_case_367
+		case 368:
+			goto st_case_368
+		case 369:
+			goto st_case_369
+		case 370:
+			goto st_case_370
+		case 371:
+			goto st_case_371
+		case 372:
+			goto st_case_372
+		case 373:
+			goto st_case_373
+		case 374:
+			goto st_case_374
+		case 375:
+			goto st_case_375
+		case 376:
+			goto st_case_376
+		case 377:
+			goto st_case_377
+		case 378:
+			goto st_case_378
+		case 379:
+			goto st_case_379
+		case 380:
+			goto st_case_380
+		case 381:
+			goto st_case_381
+		case 382:
+			goto st_case_382
+		case 383:
+			goto st_case_383
+		case 384:
+			goto st_case_384
+		case 385:
+			goto st_case_385
+		case 386:
+			goto st_case_386
+		case 387:
+			goto st_case_387
+		case 388:
+			goto st_case_388
+		case 389:
+			goto st_case_389
+		case 390:
+			goto st_case_390
+		case 391:
+			goto st_case_391
+		case 392:
+			goto st_case_392
+		case 393:
+			goto st_case_393
+		case 394:
+			goto st_case_394
+		case 395:
+			goto st_case_395
+		case 396:
+			goto st_case_396
+		case 397:
+			goto st_case_397
+		case 398:
+			goto st_case_398
+		case 399:
+			goto st_case_399
+		case 400:
+			goto st_case_400
+		case 401:
+			goto st_case_401
+		case 402:
+			goto st_case_402
+		case 403:
+			goto st_case_403
+		case 404:
+			goto st_case_404
+		case 405:
+			goto st_case_405
+		case 406:
+			goto st_case_406
+		case 407:
+			goto st_case_407
+		case 408:
+			goto st_case_408
+		case 409:
+			goto st_case_409
+		case 410:
+			goto st_case_410
+		case 411:
+			goto st_case_411
+		case 412:
+			goto st_case_412
+		case 413:
+			goto st_case_413
+		case 414:
+			goto st_case_414
+		case 415:
+			goto st_case_415
+		case 416:
+			goto st_case_416
+		case 417:
+			goto st_case_417
+		case 418:
+			goto st_case_418
+		case 419:
+			goto st_case_419
+		case 420:
+			goto st_case_420
+		case 421:
+			goto st_case_421
+		case 422:
+			goto st_case_422
+		case 423:
+			goto st_case_423
+		case 424:
+			goto st_case_424
+		case 425:
+			goto st_case_425
+		case 426:
+			goto st_case_426
+		case 427:
+			goto st_case_427
+		case 428:
+			goto st_case_428
+		case 429:
+			goto st_case_429
+		case 430:
+			goto st_case_430
+		case 431:
+			goto st_case_431
+		case 432:
+			goto st_case_432
+		case 433:
+			goto st_case_433
+		case 434:
+			goto st_case_434
+		case 435:
+			goto st_case_435
+		case 436:
+			goto st_case_436
+		case 437:
+			goto st_case_437
+		case 438:
+			goto st_case_438
+		case 439:
+			goto st_case_439
+		case 440:
+			goto st_case_440
+		case 441:
+			goto st_case_441
+		case 442:
+			goto st_case_442
+		case 443:
+			goto st_case_443
+		case 444:
+			goto st_case_444
+		case 445:
+			goto st_case_445
+		case 446:
+			goto st_case_446
+		case 447:
+			goto st_case_447
+		case 448:
+			goto st_case_448
+		case 449:
+			goto st_case_449
+		case 450:
+			goto st_case_450
+		case 451:
+			goto st_case_451
+		case 452:
+			goto st_case_452
+		case 453:
+			goto st_case_453
+		case 454:
+			goto st_case_454
+		case 455:
+			goto st_case_455
+		case 456:
+			goto st_case_456
+		case 457:
+			goto st_case_457
+		case 458:
+			goto st_case_458
+		case 459:
+			goto st_case_459
+		case 460:
+			goto st_case_460
+		case 461:
+			goto st_case_461
+		case 462:
+			goto st_case_462
+		case 463:
+			goto st_case_463
+		case 464:
+			goto st_case_464
+		case 465:
+			goto st_case_465
+		case 466:
+			goto st_case_466
+		case 467:
+			goto st_case_467
+		case 468:
+			goto st_case_468
+		case 469:
+			goto st_case_469
+		case 470:
+			goto st_case_470
+		case 471:
+			goto st_case_471
+		case 472:
+			goto st_case_472
+		case 473:
+			goto st_case_473
+		case 474:
+			goto st_case_474
+		case 475:
+			goto st_case_475
+		case 476:
+			goto st_case_476
+		case 477:
+			goto st_case_477
+		case 478:
+			goto st_case_478
+		case 479:
+			goto st_case_479
+		case 480:
+			goto st_case_480
+		case 481:
+			goto st_case_481
+		case 482:
+			goto st_case_482
+		case 483:
+			goto st_case_483
+		case 484:
+			goto st_case_484
+		case 485:
+			goto st_case_485
+		case 486:
+			goto st_case_486
+		case 487:
+			goto st_case_487
+		case 488:
+			goto st_case_488
+		case 489:
+			goto st_case_489
+		case 490:
+			goto st_case_490
+		case 491:
+			goto st_case_491
+		case 492:
+			goto st_case_492
+		case 493:
+			goto st_case_493
+		case 494:
+			goto st_case_494
+		case 495:
+			goto st_case_495
+		case 496:
+			goto st_case_496
+		case 497:
+			goto st_case_497
+		case 498:
+			goto st_case_498
+		case 499:
+			goto st_case_499
+		case 500:
+			goto st_case_500
+		case 501:
+			goto st_case_501
+		case 502:
+			goto st_case_502
+		case 503:
+			goto st_case_503
+		case 504:
+			goto st_case_504
+		case 505:
+			goto st_case_505
+		case 506:
+			goto st_case_506
+		case 507:
+			goto st_case_507
+		case 508:
+			goto st_case_508
+		case 509:
+			goto st_case_509
+		case 510:
+			goto st_case_510
+		case 511:
+			goto st_case_511
+		case 512:
+			goto st_case_512
+		case 513:
+			goto st_case_513
+		case 514:
+			goto st_case_514
+		case 515:
+			goto st_case_515
+		case 516:
+			goto st_case_516
+		case 517:
+			goto st_case_517
+		case 518:
+			goto st_case_518
+		case 519:
+			goto st_case_519
+		case 520:
+			goto st_case_520
+		case 521:
+			goto st_case_521
+		case 522:
+			goto st_case_522
+		case 523:
+			goto st_case_523
+		case 524:
+			goto st_case_524
+		case 525:
+			goto st_case_525
+		case 526:
+			goto st_case_526
+		case 527:
+			goto st_case_527
+		case 528:
+			goto st_case_528
+		case 529:
+			goto st_case_529
+		case 530:
+			goto st_case_530
+		case 531:
+			goto st_case_531
+		case 532:
+			goto st_case_532
+		case 533:
+			goto st_case_533
+		case 534:
+			goto st_case_534
+		case 535:
+			goto st_case_535
+		case 536:
+			goto st_case_536
+		case 537:
+			goto st_case_537
+		case 538:
+			goto st_case_538
+		case 539:
+			goto st_case_539
+		case 540:
+			goto st_case_540
+		case 541:
+			goto st_case_541
+		case 542:
+			goto st_case_542
+		case 543:
+			goto st_case_543
+		case 544:
+			goto st_case_544
+		case 545:
+			goto st_case_545
+		case 546:
+			goto st_case_546
+		case 547:
+			goto st_case_547
+		case 548:
+			goto st_case_548
+		case 549:
+			goto st_case_549
+		case 550:
+			goto st_case_550
+		case 551:
+			goto st_case_551
+		case 552:
+			goto st_case_552
+		case 553:
+			goto st_case_553
+		case 554:
+			goto st_case_554
+		case 555:
+			goto st_case_555
+		case 556:
+			goto st_case_556
+		case 557:
+			goto st_case_557
+		case 558:
+			goto st_case_558
+		case 559:
+			goto st_case_559
+		case 560:
+			goto st_case_560
+		case 561:
+			goto st_case_561
+		case 562:
+			goto st_case_562
+		case 563:
+			goto st_case_563
+		case 564:
+			goto st_case_564
+		case 565:
+			goto st_case_565
+		case 566:
+			goto st_case_566
+		case 567:
+			goto st_case_567
+		case 568:
+			goto st_case_568
+		case 569:
+			goto st_case_569
+		case 570:
+			goto st_case_570
+		case 571:
+			goto st_case_571
+		case 572:
+			goto st_case_572
+		case 573:
+			goto st_case_573
+		case 574:
+			goto st_case_574
+		case 575:
+			goto st_case_575
+		case 576:
+			goto st_case_576
+		case 577:
+			goto st_case_577
+		case 578:
+			goto st_case_578
+		case 579:
+			goto st_case_579
+		case 580:
+			goto st_case_580
+		case 581:
+			goto st_case_581
+		case 582:
+			goto st_case_582
+		case 583:
+			goto st_case_583
+		case 584:
+			goto st_case_584
+		case 585:
+			goto st_case_585
+		case 586:
+			goto st_case_586
+		case 587:
+			goto st_case_587
+		case 588:
+			goto st_case_588
+		case 589:
+			goto st_case_589
+		case 590:
+			goto st_case_590
+		case 591:
+			goto st_case_591
+		case 592:
+			goto st_case_592
+		case 593:
+			goto st_case_593
+		case 594:
+			goto st_case_594
+		case 595:
+			goto st_case_595
+		case 596:
+			goto st_case_596
+		}
+		goto st_out
+	tr0:
 //line NONE:1
-	switch  lex.act {
-	case 6:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SCONST; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 8:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CAST; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 9:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = AT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 10:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SETOF; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 12:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = INTEGER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 13:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SMALLINT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 14:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BIGINT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 15:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = REAL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 16:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = FLOAT_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 17:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DOUBLE_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 18:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DECIMAL_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 20:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = NUMERIC; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 21:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BOOLEAN_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 22:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BIT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 23:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = INTERVAL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 24:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = YEAR_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 25:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = MONTH_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 26:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DAY_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 27:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = HOUR_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 28:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = MINUTE_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 29:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SECOND_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 32:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = VARCHAR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 33:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = NATIONAL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 34:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = NCHAR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 35:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = WITHOUT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 36:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TIME; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 37:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TYPE_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 38:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ENUM_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 39:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ZONE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 40:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = IF_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 42:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = PREPARE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 43:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DEALLOCATE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 44:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = EXECUTE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 45:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SELECT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 46:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = INSERT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 47:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = INTO; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 48:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = VALUES; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 49:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = UPDATE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 50:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DELETE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 51:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CREATE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 52:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TRUNCATE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 53:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TABLE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 54:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = EXTENSION; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 55:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SCHEMA; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 56:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DATABASE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 57:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ROLE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 58:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = PRIMARY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 59:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = UNIQUE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 60:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = FOREIGN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 61:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CHECK; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 62:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = REFERENCES; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 63:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = KEY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 65:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = RESET; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 66:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SHOW; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 67:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = FROM; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 68:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = WHERE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 69:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ORDER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 70:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = GROUP; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 71:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 72:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = HAVING; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 74:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = AND; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 76:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = GRANT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 77:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = REVOKE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 78:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = EXPLAIN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 79:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = RETURNING; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 80:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DEFAULT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 81:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = COPY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 82:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = EXTRACT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 83:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TO; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 84:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = STDOUT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 85:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LIMIT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 86:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = OFFSET; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 87:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DISTINCT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 88:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LIKE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 89:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ILIKE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 91:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ISNULL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 93:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = NULLS_LA; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 95:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = NORMALIZE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 96:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = NOTNULL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 97:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LATERAL_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 98:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ORDINALITY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 100:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TRUE_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 101:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = FALSE_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 102:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = FIRST_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 103:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = FILTER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 104:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LAST_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 105:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ASC; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 106:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DESC; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 107:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SESSION; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 108:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LOCAL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 109:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CURRENT_USER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 110:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CHARACTERISTICS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 112:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ISOLATION; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 113:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LEVEL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 114:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = COMMITTED; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 115:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CASCADE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 116:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = RESTRICT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 117:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ARRAY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 118:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ROW; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 119:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = EXISTS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 120:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DISCARD; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 121:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = PLANS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 122:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SEQUENCES; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 123:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = JOIN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 124:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CROSS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 125:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LEFT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 126:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = RIGHT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 127:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = FULL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 128:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = OUTER_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 129:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = INNER_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 133:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = LOCKED; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 134:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SKIP; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 135:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = RECURSIVE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 136:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SEARCH; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 137:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CYCLE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 138:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BREADTH; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 139:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DEPTH; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 140:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SHARE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 141:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = USING; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 142:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = VACUUM; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 143:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CLUSTER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 144:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ANALYZE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 145:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ALTER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 146:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = INDEX; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 147:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BINARY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 148:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DELIMITERS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 150:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CSV; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 151:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = HEADER_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 152:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = QUOTE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 153:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ESCAPE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 154:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ENCODING; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 155:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = PROGRAM; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 156:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = STDIN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 157:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ASYMMETRIC; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 158:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BETWEEN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 159:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DROP; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 160:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = BEGIN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 161:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ELSE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 162:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = END_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 163:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TRANSACTION; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 164:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = READ; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 165:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ONLY; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 166:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = WRITE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 167:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = DEFERRABLE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 170:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = UNCOMMITTED; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 172:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = REPEATABLE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 173:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = SERIALIZABLE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 174:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = START; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 175:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ABORT_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 177:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ROLLBACK; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 179:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CASE; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 180:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = WHEN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 181:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = THEN; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 183:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CONFLICT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 185:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = NOTHING; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 187:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = UNION; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 188:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = EXCEPT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 189:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = INTERSECT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 190:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = ALL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 191:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = PARTITION; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 192:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = CONVERSION_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 193:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = STATISTICS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 195:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = IDENT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 202:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TDOT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 205:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TPLUS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 206:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TMINUS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 207:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TMUL; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 208:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TMOD; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 209:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TPOW; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 210:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TLESS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 211:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TGREATER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 212:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TEQ; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 213:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TNOT_EQUALS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 214:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TLESS_EQUALS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 215:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TGREATER_EQUALS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 216:
-	{( lex.p) = ( lex.te) - 1
- lval.str = string(lex.data[lex.ts:lex.te]); tok = TNOT_EQUALS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	case 217:
-	{( lex.p) = ( lex.te) - 1
+		switch lex.act {
+		case 6:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SCONST
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 8:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CAST
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 9:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = AT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 10:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SETOF
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 12:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = INTEGER
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 13:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SMALLINT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 14:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BIGINT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 15:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = REAL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 16:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = FLOAT_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 17:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DOUBLE_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 18:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DECIMAL_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 20:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = NUMERIC
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 21:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BOOLEAN_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 22:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BIT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 23:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = INTERVAL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 24:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = YEAR_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 25:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = MONTH_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 26:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DAY_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 27:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = HOUR_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 28:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = MINUTE_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 29:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SECOND_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 32:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = VARCHAR
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 33:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = NATIONAL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 34:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = NCHAR
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 35:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = WITHOUT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 36:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TIME
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 37:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TYPE_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 38:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ENUM_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 39:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ZONE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 40:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = IF_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 42:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = PREPARE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 43:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DEALLOCATE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 44:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = EXECUTE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 45:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SELECT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 46:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = INSERT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 47:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = INTO
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 48:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = VALUES
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 49:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = UPDATE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 50:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DELETE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 51:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CREATE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 52:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TRUNCATE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 53:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TABLE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 54:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = EXTENSION
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 55:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SCHEMA
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 56:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DATABASE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 57:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ROLE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 58:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = PRIMARY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 59:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = UNIQUE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 60:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = FOREIGN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 61:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CHECK
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 62:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = REFERENCES
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 63:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = KEY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 65:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = RESET
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 66:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SHOW
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 67:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = FROM
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 68:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = WHERE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 69:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ORDER
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 70:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = GROUP
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 71:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 72:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = HAVING
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 74:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = AND
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 76:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = GRANT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 77:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = REVOKE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 78:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = EXPLAIN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 79:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = RETURNING
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 80:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DEFAULT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 81:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = COPY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 82:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = EXTRACT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 83:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TO
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 84:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = STDOUT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 85:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LIMIT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 86:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = OFFSET
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 87:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DISTINCT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 88:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LIKE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 89:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ILIKE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 91:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ISNULL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 93:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = NULLS_LA
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 95:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = NORMALIZE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 96:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = NOTNULL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 97:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LATERAL_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 98:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ORDINALITY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 100:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TRUE_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 101:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = FALSE_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 102:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = FIRST_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 103:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = FILTER
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 104:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LAST_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 105:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ASC
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 106:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DESC
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 107:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SESSION
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 108:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LOCAL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 109:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CURRENT_USER
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 110:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CHARACTERISTICS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 112:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ISOLATION
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 113:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LEVEL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 114:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = COMMITTED
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 115:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CASCADE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 116:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = RESTRICT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 117:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ARRAY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 118:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ROW
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 119:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = EXISTS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 120:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DISCARD
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 121:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = PLANS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 122:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SEQUENCES
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 123:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = JOIN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 124:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CROSS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 125:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LEFT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 126:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = RIGHT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 127:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = FULL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 128:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = OUTER_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 129:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = INNER_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 133:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = LOCKED
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 134:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SKIP
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 135:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = RECURSIVE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 136:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SEARCH
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 137:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CYCLE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 138:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BREADTH
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 139:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DEPTH
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 140:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SHARE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 141:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = USING
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 142:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = VACUUM
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 143:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CLUSTER
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 144:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ANALYZE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 145:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ALTER
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 146:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = INDEX
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 147:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BINARY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 148:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DELIMITERS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 150:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CSV
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 151:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = HEADER_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 152:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = QUOTE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 153:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ESCAPE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 154:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ENCODING
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 155:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = PROGRAM
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 156:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = STDIN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 157:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ASYMMETRIC
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 158:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BETWEEN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 159:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DROP
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 160:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = BEGIN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 161:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ELSE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 162:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = END_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 163:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TRANSACTION
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 164:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = READ
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 165:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ONLY
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 166:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = WRITE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 167:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = DEFERRABLE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 170:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = UNCOMMITTED
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 172:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = REPEATABLE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 173:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = SERIALIZABLE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 174:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = START
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 175:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ABORT_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 177:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ROLLBACK
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 179:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CASE
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 180:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = WHEN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 181:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = THEN
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 183:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CONFLICT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 185:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = NOTHING
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 187:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = UNION
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 188:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = EXCEPT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 189:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = INTERSECT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 190:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = ALL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 191:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = PARTITION
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 192:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = CONVERSION_P
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 193:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = STATISTICS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 195:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = IDENT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 202:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TDOT
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 205:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TPLUS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 206:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TMINUS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 207:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TMUL
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 208:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TMOD
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 209:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TPOW
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 210:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TLESS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 211:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TGREATER
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 212:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TEQ
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 213:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TNOT_EQUALS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 214:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TLESS_EQUALS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 215:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TGREATER_EQUALS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 216:
+			{
+				(lex.p) = (lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = TNOT_EQUALS
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 217:
+			{
+				(lex.p) = (lex.te) - 1
 
-                lval.str = string(lex.data[lex.ts:lex.te]); tok = int(OP);    
-                {( lex.p)++;  lex.cs = 9; goto _out }
-            }
-	case 218:
-	{( lex.p) = ( lex.te) - 1
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = int(OP)
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		case 218:
+			{
+				(lex.p) = (lex.te) - 1
 
-                lval.str = string(lex.data[lex.ts:lex.te]); tok = int(OP);    
-                {( lex.p)++;  lex.cs = 9; goto _out }
-            }
-	}
-	
-	goto st9
-tr5:
+				lval.str = string(lex.data[lex.ts:lex.te])
+				tok = int(OP)
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		}
+
+		goto st9
+	tr5:
 //line lyx/lexer.rl:362
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts + 1:lex.te - 1]); tok = IDENT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr8:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts+1 : lex.te-1])
+			tok = IDENT
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr8:
 //line lyx/lexer.rl:364
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts + 1:lex.te - 1]); tok = SCONST; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr9:
+		lex.te = (lex.p) + 1
+		{
+			val := string(lex.data[lex.ts+1 : lex.te-1])
+			if lex.hasEscapedQuotePlaceholder {
+				val = restoreEscapedQuotes(val)
+			}
+			lval.str = val
+			tok = SCONST
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr9:
 //line lyx/lexer.rl:378
-( lex.p) = ( lex.te) - 1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TMINUS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr13:
+		(lex.p) = (lex.te) - 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TMINUS
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr13:
 //line lyx/lexer.rl:101
- lex.te = ( lex.p)+1
-{/* nothing */}
-	goto st9
-tr19:
+		lex.te = (lex.p) + 1
+		{ /* nothing */
+		}
+		goto st9
+	tr19:
 //line lyx/lexer.rl:370
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TOPENBR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr20:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TOPENBR
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr20:
 //line lyx/lexer.rl:371
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TCLOSEBR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr23:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TCLOSEBR
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr23:
 //line lyx/lexer.rl:369
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TCOMMA; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr30:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TCOMMA
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr30:
 //line lyx/lexer.rl:375
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TSEMICOLON; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr60:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TSEMICOLON
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr60:
 //line lyx/lexer.rl:372
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TSQOPENBR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr61:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TSQOPENBR
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr61:
 //line lyx/lexer.rl:373
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TSQCLOSEBR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr63:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TSQCLOSEBR
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr63:
 //line lyx/lexer.rl:99
- lex.te = ( lex.p)
-( lex.p)--
-{ /* do nothing */ }
-	goto st9
-tr64:
+		lex.te = (lex.p)
+		(lex.p)--
+		{ /* do nothing */
+		}
+		goto st9
+	tr64:
 //line lyx/lexer.rl:393
- lex.te = ( lex.p)
-( lex.p)--
-{
-                lval.str = string(lex.data[lex.ts:lex.te]); tok = int(OP);    
-                {( lex.p)++;  lex.cs = 9; goto _out }
-            }
-	goto st9
-tr66:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = int(OP)
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr66:
 //line lyx/lexer.rl:104
- lex.te = ( lex.p)
-( lex.p)--
-{
-                if i, err := strconv.Atoi(string(lex.data[lex.ts+1:lex.te]));  err != nil {
-                    lval.int = 0; tok = INVALID_ICONST; {( lex.p)++;  lex.cs = 9; goto _out }
-                } else {
-                    lval.int = int(i); tok = PARAM; {( lex.p)++;  lex.cs = 9; goto _out }
-                }
-            }
-	goto st9
-tr67:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			if i, err := strconv.Atoi(string(lex.data[lex.ts+1 : lex.te])); err != nil {
+				lval.int = 0
+				tok = INVALID_ICONST
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			} else {
+				lval.int = int(i)
+				tok = PARAM
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		}
+		goto st9
+	tr67:
 //line lyx/lexer.rl:378
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TMINUS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr71:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TMINUS
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr71:
 //line lyx/lexer.rl:101
- lex.te = ( lex.p)
-( lex.p)--
-{/* nothing */}
-	goto st9
-tr73:
+		lex.te = (lex.p)
+		(lex.p)--
+		{ /* nothing */
+		}
+		goto st9
+	tr73:
 //line lyx/lexer.rl:119
- lex.te = ( lex.p)
-( lex.p)--
-{ 
-                if v, err := strconv.Atoi(string(lex.data[lex.ts:lex.te]));  err != nil {
-                   lval.int = 0; tok = INVALID_ICONST; {( lex.p)++;  lex.cs = 9; goto _out }
-                } else {
-                   lval.int = v; tok = ICONST; {( lex.p)++;  lex.cs = 9; goto _out }
-                }
-            }
-	goto st9
-tr74:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			if v, err := strconv.Atoi(string(lex.data[lex.ts:lex.te])); err != nil {
+				lval.int = 0
+				tok = INVALID_ICONST
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			} else {
+				lval.int = v
+				tok = ICONST
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		}
+		goto st9
+	tr74:
 //line lyx/lexer.rl:112
- lex.te = ( lex.p)
-( lex.p)--
-{ 
-                if v, err := strconv.Atoi(string(lex.data[lex.ts:lex.te]));  err != nil {
-                   lval.int = 0; tok = INVALID_ICONST; {( lex.p)++;  lex.cs = 9; goto _out }
-                } else {
-                   lval.int = v; tok = ICONST; {( lex.p)++;  lex.cs = 9; goto _out }
-                }
-            }
-	goto st9
-tr75:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			if v, err := strconv.Atoi(string(lex.data[lex.ts:lex.te])); err != nil {
+				lval.int = 0
+				tok = INVALID_ICONST
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			} else {
+				lval.int = v
+				tok = ICONST
+				{
+					(lex.p)++
+					lex.cs = 9
+					goto _out
+				}
+			}
+		}
+		goto st9
+	tr75:
 //line lyx/lexer.rl:376
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TCOLON; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr76:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TCOLON
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr76:
 //line lyx/lexer.rl:129
- lex.te = ( lex.p)+1
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TYPECAST; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr77:
+		lex.te = (lex.p) + 1
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TYPECAST
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr77:
 //line lyx/lexer.rl:383
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TLESS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr80:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TLESS
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr80:
 //line lyx/lexer.rl:384
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = TGREATER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr82:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = TGREATER
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr82:
 //line lyx/lexer.rl:363
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = IDENT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr105:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = IDENT
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr105:
 //line lyx/lexer.rl:206
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = AS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr165:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = AS
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr165:
 //line lyx/lexer.rl:159
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = CHAR_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr171:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = CHAR_P
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr171:
 //line lyx/lexer.rl:158
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = CHARACTER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr191:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = CHARACTER
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr191:
 //line lyx/lexer.rl:340
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = COMMIT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr254:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = COMMIT
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr254:
 //line lyx/lexer.rl:143
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = DEC; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr279:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = DEC
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr279:
 //line lyx/lexer.rl:307
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = DELIMITER; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr294:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = DELIMITER
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr294:
 //line lyx/lexer.rl:350
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = DO; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr369:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = DO
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr369:
 //line lyx/lexer.rl:281
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = FOR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr405:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = FOR
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr405:
 //line lyx/lexer.rl:280
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = IN_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr417:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = IN_P
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr417:
 //line lyx/lexer.rl:135
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = INT_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr431:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = INT_P
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr431:
 //line lyx/lexer.rl:229
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = IS; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr505:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = IS
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr505:
 //line lyx/lexer.rl:233
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = NOT; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr517:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = NOT
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr517:
 //line lyx/lexer.rl:231
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = NULL_P; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr527:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = NULL_P
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr527:
 //line lyx/lexer.rl:172
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = OF; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr532:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = OF
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr532:
 //line lyx/lexer.rl:279
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = ON; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr535:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = ON
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr535:
 //line lyx/lexer.rl:208
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = OR; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr685:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = OR
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr685:
 //line lyx/lexer.rl:197
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = SET; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
-tr796:
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = SET
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
+	tr796:
 //line lyx/lexer.rl:238
- lex.te = ( lex.p)
-( lex.p)--
-{ lval.str = string(lex.data[lex.ts:lex.te]); tok = WITH; {( lex.p)++;  lex.cs = 9; goto _out }}
-	goto st9
+		lex.te = (lex.p)
+		(lex.p)--
+		{
+			lval.str = string(lex.data[lex.ts:lex.te])
+			tok = WITH
+			{
+				(lex.p)++
+				lex.cs = 9
+				goto _out
+			}
+		}
+		goto st9
 	st9:
 //line NONE:1
- lex.ts = 0
+		lex.ts = 0
 
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof9
 		}
 	st_case_9:
 //line NONE:1
- lex.ts = ( lex.p)
+		lex.ts = (lex.p)
 
 //line lyx/lexer.go:2082
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 32:
 			goto st10
 		case 33:
@@ -2238,58 +4016,58 @@ tr796:
 			goto tr16
 		}
 		switch {
-		case  lex.data[( lex.p)] < 48:
+		case lex.data[(lex.p)] < 48:
 			switch {
-			case  lex.data[( lex.p)] > 13:
-				if 35 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 38 {
+			case lex.data[(lex.p)] > 13:
+				if 35 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 38 {
 					goto tr16
 				}
-			case  lex.data[( lex.p)] >= 9:
+			case lex.data[(lex.p)] >= 9:
 				goto st10
 			}
-		case  lex.data[( lex.p)] > 51:
+		case lex.data[(lex.p)] > 51:
 			switch {
-			case  lex.data[( lex.p)] > 57:
-				if 63 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 96 {
+			case lex.data[(lex.p)] > 57:
+				if 63 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 96 {
 					goto tr16
 				}
-			case  lex.data[( lex.p)] >= 52:
+			case lex.data[(lex.p)] >= 52:
 				goto st21
 			}
 		default:
 			goto st19
 		}
 		goto st0
-st_case_0:
+	st_case_0:
 	st0:
-		 lex.cs = 0
+		lex.cs = 0
 		goto _out
 	st10:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof10
 		}
 	st_case_10:
-		if  lex.data[( lex.p)] == 32 {
+		if lex.data[(lex.p)] == 32 {
 			goto st10
 		}
-		if 9 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 13 {
+		if 9 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 13 {
 			goto st10
 		}
 		goto tr63
-tr15:
+	tr15:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:393
- lex.act = 217;
-	goto st11
+		lex.act = 217
+		goto st11
 	st11:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof11
 		}
 	st_case_11:
 //line lyx/lexer.go:2292
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 33:
 			goto tr1
 		case 35:
@@ -2314,98 +4092,98 @@ tr15:
 			goto tr1
 		}
 		switch {
-		case  lex.data[( lex.p)] > 38:
-			if 60 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 64 {
+		case lex.data[(lex.p)] > 38:
+			if 60 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
 				goto tr1
 			}
-		case  lex.data[( lex.p)] >= 37:
+		case lex.data[(lex.p)] >= 37:
 			goto tr1
 		}
 		goto tr64
-tr1:
+	tr1:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:397
- lex.act = 218;
-	goto st12
-tr16:
+		lex.act = 218
+		goto st12
+	tr16:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:393
- lex.act = 217;
-	goto st12
-tr18:
+		lex.act = 217
+		goto st12
+	tr18:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:381
- lex.act = 208;
-	goto st12
-tr21:
+		lex.act = 208
+		goto st12
+	tr21:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:379
- lex.act = 207;
-	goto st12
-tr22:
+		lex.act = 207
+		goto st12
+	tr22:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:377
- lex.act = 205;
-	goto st12
-tr32:
+		lex.act = 205
+		goto st12
+	tr32:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:385
- lex.act = 212;
-	goto st12
-tr62:
+		lex.act = 212
+		goto st12
+	tr62:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:382
- lex.act = 209;
-	goto st12
-tr65:
+		lex.act = 209
+		goto st12
+	tr65:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:390
- lex.act = 216;
-	goto st12
-tr78:
+		lex.act = 216
+		goto st12
+	tr78:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:388
- lex.act = 214;
-	goto st12
-tr79:
+		lex.act = 214
+		goto st12
+	tr79:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:387
- lex.act = 213;
-	goto st12
-tr81:
+		lex.act = 213
+		goto st12
+	tr81:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:389
- lex.act = 215;
-	goto st12
+		lex.act = 215
+		goto st12
 	st12:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof12
 		}
 	st_case_12:
 //line lyx/lexer.go:2408
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 33:
 			goto tr1
 		case 35:
@@ -2428,20 +4206,20 @@ tr81:
 			goto tr1
 		}
 		switch {
-		case  lex.data[( lex.p)] > 38:
-			if 60 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 64 {
+		case lex.data[(lex.p)] > 38:
+			if 60 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
 				goto tr1
 			}
-		case  lex.data[( lex.p)] >= 37:
+		case lex.data[(lex.p)] >= 37:
 			goto tr1
 		}
 		goto tr0
 	st1:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof1
 		}
 	st_case_1:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 33:
 			goto tr1
 		case 35:
@@ -2464,20 +4242,20 @@ tr81:
 			goto tr1
 		}
 		switch {
-		case  lex.data[( lex.p)] > 38:
-			if 60 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 64 {
+		case lex.data[(lex.p)] > 38:
+			if 60 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
 				goto tr1
 			}
-		case  lex.data[( lex.p)] >= 37:
+		case lex.data[(lex.p)] >= 37:
 			goto tr1
 		}
 		goto tr0
 	st2:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof2
 		}
 	st_case_2:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 10:
 			goto st0
 		case 13:
@@ -2487,46 +4265,46 @@ tr81:
 		}
 		goto st2
 	st3:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof3
 		}
 	st_case_3:
-		if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto st13
 		}
 		goto st0
 	st13:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof13
 		}
 	st_case_13:
-		if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto st13
 		}
 		goto tr66
 	st4:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof4
 		}
 	st_case_4:
-		if  lex.data[( lex.p)] == 39 {
+		if lex.data[(lex.p)] == 39 {
 			goto tr8
 		}
 		goto st4
-tr24:
+	tr24:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:378
- lex.act = 206;
-	goto st14
+		lex.act = 206
+		goto st14
 	st14:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof14
 		}
 	st_case_14:
 //line lyx/lexer.go:2529
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 33:
 			goto tr1
 		case 35:
@@ -2551,12 +4329,12 @@ tr24:
 			goto tr1
 		}
 		switch {
-		case  lex.data[( lex.p)] < 48:
-			if 37 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 38 {
+		case lex.data[(lex.p)] < 48:
+			if 37 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 38 {
 				goto tr1
 			}
-		case  lex.data[( lex.p)] > 57:
-			if 60 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 64 {
+		case lex.data[(lex.p)] > 57:
+			if 60 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
 				goto tr1
 			}
 		default:
@@ -2564,11 +4342,11 @@ tr24:
 		}
 		goto tr67
 	st15:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof15
 		}
 	st_case_15:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr71
 		case 13:
@@ -2591,12 +4369,12 @@ tr24:
 			goto st15
 		}
 		switch {
-		case  lex.data[( lex.p)] < 42:
-			if 37 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 38 {
+		case lex.data[(lex.p)] < 42:
+			if 37 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 38 {
 				goto st15
 			}
-		case  lex.data[( lex.p)] > 43:
-			if 60 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 64 {
+		case lex.data[(lex.p)] > 43:
+			if 60 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
 				goto st15
 			}
 		default:
@@ -2604,11 +4382,11 @@ tr24:
 		}
 		goto st16
 	st16:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof16
 		}
 	st_case_16:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 10:
 			goto tr71
 		case 13:
@@ -2616,74 +4394,74 @@ tr24:
 		}
 		goto st16
 	st5:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof5
 		}
 	st_case_5:
-		if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr10
 		}
 		goto tr9
-tr10:
+	tr10:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:127
- lex.act = 6;
-	goto st17
-tr25:
+		lex.act = 6
+		goto st17
+	tr25:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:374
- lex.act = 202;
-	goto st17
+		lex.act = 202
+		goto st17
 	st17:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof17
 		}
 	st_case_17:
 //line lyx/lexer.go:2647
-		if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto tr10
 		}
 		goto tr0
 	st18:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof18
 		}
 	st_case_18:
-		if  lex.data[( lex.p)] == 46 {
+		if lex.data[(lex.p)] == 46 {
 			goto tr10
 		}
-		if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto st18
 		}
 		goto tr73
 	st6:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof6
 		}
 	st_case_6:
-		if  lex.data[( lex.p)] == 42 {
+		if lex.data[(lex.p)] == 42 {
 			goto st7
 		}
 		goto st0
 	st7:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof7
 		}
 	st_case_7:
-		if  lex.data[( lex.p)] == 42 {
+		if lex.data[(lex.p)] == 42 {
 			goto st8
 		}
 		goto st7
 	st8:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof8
 		}
 	st_case_8:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 42:
 			goto st8
 		case 47:
@@ -2691,11 +4469,11 @@ tr25:
 		}
 		goto st7
 	st19:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof19
 		}
 	st_case_19:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 46:
@@ -2704,1171 +4482,1171 @@ tr25:
 			goto tr57
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto st19
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
 			goto tr57
 		}
 		goto tr74
-tr57:
+	tr57:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:363
- lex.act = 195;
-	goto st20
-tr88:
+		lex.act = 195
+		goto st20
+	tr88:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:132
- lex.act = 9;
-	goto st20
-tr91:
+		lex.act = 9
+		goto st20
+	tr91:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:337
- lex.act = 175;
-	goto st20
-tr92:
+		lex.act = 175
+		goto st20
+	tr92:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:355
- lex.act = 190;
-	goto st20
-tr95:
+		lex.act = 190
+		goto st20
+	tr95:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:301
- lex.act = 145;
-	goto st20
-tr97:
+		lex.act = 145
+		goto st20
+	tr97:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:207
- lex.act = 74;
-	goto st20
-tr101:
+		lex.act = 74
+		goto st20
+	tr101:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:299
- lex.act = 144;
-	goto st20
-tr104:
+		lex.act = 144
+		goto st20
+	tr104:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:262
- lex.act = 117;
-	goto st20
-tr106:
+		lex.act = 117
+		goto st20
+	tr106:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:245
- lex.act = 105;
-	goto st20
-tr114:
+		lex.act = 105
+		goto st20
+	tr114:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:316
- lex.act = 157;
-	goto st20
-tr119:
+		lex.act = 157
+		goto st20
+	tr119:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:204
- lex.act = 71;
-	goto st20
-tr123:
+		lex.act = 71
+		goto st20
+	tr123:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:321
- lex.act = 160;
-	goto st20
-tr127:
+		lex.act = 160
+		goto st20
+	tr127:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:317
- lex.act = 158;
-	goto st20
-tr130:
+		lex.act = 158
+		goto st20
+	tr130:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:146
- lex.act = 22;
-	goto st20
-tr133:
+		lex.act = 22
+		goto st20
+	tr133:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:138
- lex.act = 14;
-	goto st20
-tr136:
+		lex.act = 14
+		goto st20
+	tr136:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:305
- lex.act = 147;
-	goto st20
-tr141:
+		lex.act = 147
+		goto st20
+	tr141:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:145
- lex.act = 21;
-	goto st20
-tr146:
+		lex.act = 21
+		goto st20
+	tr146:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:290
- lex.act = 138;
-	goto st20
-tr157:
+		lex.act = 138
+		goto st20
+	tr157:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:342
- lex.act = 179;
-	goto st20
-tr158:
+		lex.act = 179
+		goto st20
+	tr158:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:131
- lex.act = 8;
-	goto st20
-tr161:
+		lex.act = 8
+		goto st20
+	tr161:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:259
- lex.act = 115;
-	goto st20
-tr177:
+		lex.act = 115
+		goto st20
+	tr177:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:252
- lex.act = 110;
-	goto st20
-tr179:
+		lex.act = 110
+		goto st20
+	tr179:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:194
- lex.act = 61;
-	goto st20
-tr184:
+		lex.act = 61
+		goto st20
+	tr184:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:298
- lex.act = 143;
-	goto st20
-tr194:
+		lex.act = 143
+		goto st20
+	tr194:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:257
- lex.act = 114;
-	goto st20
-tr200:
+		lex.act = 114
+		goto st20
+	tr200:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:347
- lex.act = 183;
-	goto st20
-tr206:
+		lex.act = 183
+		goto st20
+	tr206:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:359
- lex.act = 192;
-	goto st20
-tr207:
+		lex.act = 192
+		goto st20
+	tr207:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:218
- lex.act = 81;
-	goto st20
-tr212:
+		lex.act = 81
+		goto st20
+	tr212:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:184
- lex.act = 51;
-	goto st20
-tr214:
+		lex.act = 51
+		goto st20
+	tr214:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:273
- lex.act = 124;
-	goto st20
-tr215:
+		lex.act = 124
+		goto st20
+	tr215:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:308
- lex.act = 150;
-	goto st20
-tr225:
+		lex.act = 150
+		goto st20
+	tr225:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:250
- lex.act = 109;
-	goto st20
-tr228:
+		lex.act = 109
+		goto st20
+	tr228:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:289
- lex.act = 137;
-	goto st20
-tr235:
+		lex.act = 137
+		goto st20
+	tr235:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:152
- lex.act = 26;
-	goto st20
-tr240:
+		lex.act = 26
+		goto st20
+	tr240:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:189
- lex.act = 56;
-	goto st20
-tr253:
+		lex.act = 56
+		goto st20
+	tr253:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:175
- lex.act = 43;
-	goto st20
-tr258:
+		lex.act = 43
+		goto st20
+	tr258:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:142
- lex.act = 18;
-	goto st20
-tr263:
+		lex.act = 18
+		goto st20
+	tr263:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:216
- lex.act = 80;
-	goto st20
-tr269:
+		lex.act = 80
+		goto st20
+	tr269:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:328
- lex.act = 167;
-	goto st20
-tr273:
+		lex.act = 167
+		goto st20
+	tr273:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:183
- lex.act = 50;
-	goto st20
-tr280:
+		lex.act = 50
+		goto st20
+	tr280:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:306
- lex.act = 148;
-	goto st20
-tr282:
+		lex.act = 148
+		goto st20
+	tr282:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:291
- lex.act = 139;
-	goto st20
-tr283:
+		lex.act = 139
+		goto st20
+	tr283:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:246
- lex.act = 106;
-	goto st20
-tr289:
+		lex.act = 106
+		goto st20
+	tr289:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:268
- lex.act = 120;
-	goto st20
-tr293:
+		lex.act = 120
+		goto st20
+	tr293:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:225
- lex.act = 87;
-	goto st20
-tr298:
+		lex.act = 87
+		goto st20
+	tr298:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:141
- lex.act = 17;
-	goto st20
-tr300:
+		lex.act = 17
+		goto st20
+	tr300:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:318
- lex.act = 159;
-	goto st20
-tr306:
+		lex.act = 159
+		goto st20
+	tr306:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:322
- lex.act = 161;
-	goto st20
-tr308:
+		lex.act = 161
+		goto st20
+	tr308:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:323
- lex.act = 162;
-	goto st20
-tr314:
+		lex.act = 162
+		goto st20
+	tr314:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:312
- lex.act = 154;
-	goto st20
-tr315:
+		lex.act = 154
+		goto st20
+	tr315:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:168
- lex.act = 38;
-	goto st20
-tr319:
+		lex.act = 38
+		goto st20
+	tr319:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:311
- lex.act = 153;
-	goto st20
-tr327:
+		lex.act = 153
+		goto st20
+	tr327:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:353
- lex.act = 188;
-	goto st20
-tr331:
+		lex.act = 188
+		goto st20
+	tr331:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:176
- lex.act = 44;
-	goto st20
-tr334:
+		lex.act = 44
+		goto st20
+	tr334:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:265
- lex.act = 119;
-	goto st20
-tr338:
+		lex.act = 119
+		goto st20
+	tr338:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:213
- lex.act = 78;
-	goto st20
-tr345:
+		lex.act = 78
+		goto st20
+	tr345:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:187
- lex.act = 54;
-	goto st20
-tr348:
+		lex.act = 54
+		goto st20
+	tr348:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:219
- lex.act = 82;
-	goto st20
-tr357:
+		lex.act = 82
+		goto st20
+	tr357:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:240
- lex.act = 101;
-	goto st20
-tr362:
+		lex.act = 101
+		goto st20
+	tr362:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:243
- lex.act = 103;
-	goto st20
-tr364:
+		lex.act = 103
+		goto st20
+	tr364:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:242
- lex.act = 102;
-	goto st20
-tr367:
+		lex.act = 102
+		goto st20
+	tr367:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:140
- lex.act = 16;
-	goto st20
-tr373:
+		lex.act = 16
+		goto st20
+	tr373:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:193
- lex.act = 60;
-	goto st20
-tr375:
+		lex.act = 60
+		goto st20
+	tr375:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:200
- lex.act = 67;
-	goto st20
-tr377:
+		lex.act = 67
+		goto st20
+	tr377:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:276
- lex.act = 127;
-	goto st20
-tr382:
+		lex.act = 127
+		goto st20
+	tr382:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:210
- lex.act = 76;
-	goto st20
-tr384:
+		lex.act = 76
+		goto st20
+	tr384:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:203
- lex.act = 70;
-	goto st20
-tr391:
+		lex.act = 70
+		goto st20
+	tr391:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:205
- lex.act = 72;
-	goto st20
-tr395:
+		lex.act = 72
+		goto st20
+	tr395:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:309
- lex.act = 151;
-	goto st20
-tr397:
+		lex.act = 151
+		goto st20
+	tr397:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:153
- lex.act = 27;
-	goto st20
-tr398:
+		lex.act = 27
+		goto st20
+	tr398:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:171
- lex.act = 40;
-	goto st20
-tr404:
+		lex.act = 40
+		goto st20
+	tr404:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:227
- lex.act = 89;
-	goto st20
-tr411:
+		lex.act = 89
+		goto st20
+	tr411:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:303
- lex.act = 146;
-	goto st20
-tr413:
+		lex.act = 146
+		goto st20
+	tr413:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:278
- lex.act = 129;
-	goto st20
-tr416:
+		lex.act = 129
+		goto st20
+	tr416:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:179
- lex.act = 46;
-	goto st20
-tr419:
+		lex.act = 46
+		goto st20
+	tr419:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:180
- lex.act = 47;
-	goto st20
-tr423:
+		lex.act = 47
+		goto st20
+	tr423:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:136
- lex.act = 12;
-	goto st20
-tr428:
+		lex.act = 12
+		goto st20
+	tr428:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:354
- lex.act = 189;
-	goto st20
-tr430:
+		lex.act = 189
+		goto st20
+	tr430:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:149
- lex.act = 23;
-	goto st20
-tr436:
+		lex.act = 23
+		goto st20
+	tr436:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:230
- lex.act = 91;
-	goto st20
-tr442:
+		lex.act = 91
+		goto st20
+	tr442:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:254
- lex.act = 112;
-	goto st20
-tr445:
+		lex.act = 112
+		goto st20
+	tr445:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:272
- lex.act = 123;
-	goto st20
-tr447:
+		lex.act = 123
+		goto st20
+	tr447:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:196
- lex.act = 63;
-	goto st20
-tr454:
+		lex.act = 63
+		goto st20
+	tr454:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:244
- lex.act = 104;
-	goto st20
-tr458:
+		lex.act = 104
+		goto st20
+	tr458:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:236
- lex.act = 97;
-	goto st20
-tr461:
+		lex.act = 97
+		goto st20
+	tr461:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:274
- lex.act = 125;
-	goto st20
-tr463:
+		lex.act = 125
+		goto st20
+	tr463:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:255
- lex.act = 113;
-	goto st20
-tr466:
+		lex.act = 113
+		goto st20
+	tr466:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:226
- lex.act = 88;
-	goto st20
-tr468:
+		lex.act = 88
+		goto st20
+	tr468:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:223
- lex.act = 85;
-	goto st20
-tr472:
+		lex.act = 85
+		goto st20
+	tr472:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:249
- lex.act = 108;
-	goto st20
-tr474:
+		lex.act = 108
+		goto st20
+	tr474:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:284
- lex.act = 133;
-	goto st20
-tr480:
+		lex.act = 133
+		goto st20
+	tr480:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:154
- lex.act = 28;
-	goto st20
-tr483:
+		lex.act = 28
+		goto st20
+	tr483:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:151
- lex.act = 25;
-	goto st20
-tr493:
+		lex.act = 25
+		goto st20
+	tr493:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:161
- lex.act = 33;
-	goto st20
-tr496:
+		lex.act = 33
+		goto st20
+	tr496:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:162
- lex.act = 34;
-	goto st20
-tr504:
+		lex.act = 34
+		goto st20
+	tr504:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:234
- lex.act = 95;
-	goto st20
-tr510:
+		lex.act = 95
+		goto st20
+	tr510:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:349
- lex.act = 185;
-	goto st20
-tr513:
+		lex.act = 185
+		goto st20
+	tr513:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:235
- lex.act = 96;
-	goto st20
-tr518:
+		lex.act = 96
+		goto st20
+	tr518:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:232
- lex.act = 93;
-	goto st20
-tr522:
+		lex.act = 93
+		goto st20
+	tr522:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:144
- lex.act = 20;
-	goto st20
-tr531:
+		lex.act = 20
+		goto st20
+	tr531:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:224
- lex.act = 86;
-	goto st20
-tr534:
+		lex.act = 86
+		goto st20
+	tr534:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:326
- lex.act = 165;
-	goto st20
-tr539:
+		lex.act = 165
+		goto st20
+	tr539:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:202
- lex.act = 69;
-	goto st20
-tr545:
+		lex.act = 69
+		goto st20
+	tr545:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:237
- lex.act = 98;
-	goto st20
-tr548:
+		lex.act = 98
+		goto st20
+	tr548:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:277
- lex.act = 128;
-	goto st20
-tr558:
+		lex.act = 128
+		goto st20
+	tr558:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:357
- lex.act = 191;
-	goto st20
-tr561:
+		lex.act = 191
+		goto st20
+	tr561:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:269
- lex.act = 121;
-	goto st20
-tr568:
+		lex.act = 121
+		goto st20
+	tr568:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:174
- lex.act = 42;
-	goto st20
-tr572:
+		lex.act = 42
+		goto st20
+	tr572:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:191
- lex.act = 58;
-	goto st20
-tr576:
+		lex.act = 58
+		goto st20
+	tr576:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:313
- lex.act = 155;
-	goto st20
-tr580:
+		lex.act = 155
+		goto st20
+	tr580:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:310
- lex.act = 152;
-	goto st20
-tr591:
+		lex.act = 152
+		goto st20
+	tr591:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:325
- lex.act = 164;
-	goto st20
-tr592:
+		lex.act = 164
+		goto st20
+	tr592:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:139
- lex.act = 15;
-	goto st20
-tr598:
+		lex.act = 15
+		goto st20
+	tr598:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:287
- lex.act = 135;
-	goto st20
-tr605:
+		lex.act = 135
+		goto st20
+	tr605:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:195
- lex.act = 62;
-	goto st20
-tr612:
+		lex.act = 62
+		goto st20
+	tr612:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:333
- lex.act = 172;
-	goto st20
-tr615:
+		lex.act = 172
+		goto st20
+	tr615:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:198
- lex.act = 65;
-	goto st20
-tr619:
+		lex.act = 65
+		goto st20
+	tr619:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:260
- lex.act = 116;
-	goto st20
-tr625:
+		lex.act = 116
+		goto st20
+	tr625:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:215
- lex.act = 79;
-	goto st20
-tr628:
+		lex.act = 79
+		goto st20
+	tr628:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:211
- lex.act = 77;
-	goto st20
-tr631:
+		lex.act = 77
+		goto st20
+	tr631:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:275
- lex.act = 126;
-	goto st20
-tr633:
+		lex.act = 126
+		goto st20
+	tr633:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:264
- lex.act = 118;
-	goto st20
-tr634:
+		lex.act = 118
+		goto st20
+	tr634:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:190
- lex.act = 57;
-	goto st20
-tr639:
+		lex.act = 57
+		goto st20
+	tr639:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:339
- lex.act = 177;
-	goto st20
-tr649:
+		lex.act = 177
+		goto st20
+	tr649:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:188
- lex.act = 55;
-	goto st20
-tr659:
+		lex.act = 55
+		goto st20
+	tr659:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:288
- lex.act = 136;
-	goto st20
-tr662:
+		lex.act = 136
+		goto st20
+	tr662:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:155
- lex.act = 29;
-	goto st20
-tr665:
+		lex.act = 29
+		goto st20
+	tr665:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:178
- lex.act = 45;
-	goto st20
-tr671:
+		lex.act = 45
+		goto st20
+	tr671:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:270
- lex.act = 122;
-	goto st20
-tr680:
+		lex.act = 122
+		goto st20
+	tr680:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:334
- lex.act = 173;
-	goto st20
-tr684:
+		lex.act = 173
+		goto st20
+	tr684:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:248
- lex.act = 107;
-	goto st20
-tr687:
+		lex.act = 107
+		goto st20
+	tr687:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:134
- lex.act = 10;
-	goto st20
-tr691:
+		lex.act = 10
+		goto st20
+	tr691:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:293
- lex.act = 140;
-	goto st20
-tr692:
+		lex.act = 140
+		goto st20
+	tr692:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:199
- lex.act = 66;
-	goto st20
-tr694:
+		lex.act = 66
+		goto st20
+	tr694:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:285
- lex.act = 134;
-	goto st20
-tr700:
+		lex.act = 134
+		goto st20
+	tr700:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:137
- lex.act = 13;
-	goto st20
-tr705:
+		lex.act = 13
+		goto st20
+	tr705:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:336
- lex.act = 174;
-	goto st20
-tr711:
+		lex.act = 174
+		goto st20
+	tr711:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:360
- lex.act = 193;
-	goto st20
-tr714:
+		lex.act = 193
+		goto st20
+	tr714:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:314
- lex.act = 156;
-	goto st20
-tr716:
+		lex.act = 156
+		goto st20
+	tr716:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:221
- lex.act = 84;
-	goto st20
-tr720:
+		lex.act = 84
+		goto st20
+	tr720:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:220
- lex.act = 83;
-	goto st20
-tr725:
+		lex.act = 83
+		goto st20
+	tr725:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:186
- lex.act = 53;
-	goto st20
-tr727:
+		lex.act = 53
+		goto st20
+	tr727:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:344
- lex.act = 181;
-	goto st20
-tr729:
+		lex.act = 181
+		goto st20
+	tr729:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:166
- lex.act = 36;
-	goto st20
-tr739:
+		lex.act = 36
+		goto st20
+	tr739:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:324
- lex.act = 163;
-	goto st20
-tr740:
+		lex.act = 163
+		goto st20
+	tr740:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:239
- lex.act = 100;
-	goto st20
-tr745:
+		lex.act = 100
+		goto st20
+	tr745:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:185
- lex.act = 52;
-	goto st20
-tr747:
+		lex.act = 52
+		goto st20
+	tr747:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:167
- lex.act = 37;
-	goto st20
-tr760:
+		lex.act = 37
+		goto st20
+	tr760:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:331
- lex.act = 170;
-	goto st20
-tr763:
+		lex.act = 170
+		goto st20
+	tr763:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:352
- lex.act = 187;
-	goto st20
-tr765:
+		lex.act = 187
+		goto st20
+	tr765:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:192
- lex.act = 59;
-	goto st20
-tr769:
+		lex.act = 59
+		goto st20
+	tr769:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:182
- lex.act = 49;
-	goto st20
-tr772:
+		lex.act = 49
+		goto st20
+	tr772:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:295
- lex.act = 141;
-	goto st20
-tr779:
+		lex.act = 141
+		goto st20
+	tr779:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:297
- lex.act = 142;
-	goto st20
-tr782:
+		lex.act = 142
+		goto st20
+	tr782:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:181
- lex.act = 48;
-	goto st20
-tr786:
+		lex.act = 48
+		goto st20
+	tr786:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:160
- lex.act = 32;
-	goto st20
-tr791:
+		lex.act = 32
+		goto st20
+	tr791:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:343
- lex.act = 180;
-	goto st20
-tr793:
+		lex.act = 180
+		goto st20
+	tr793:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:201
- lex.act = 68;
-	goto st20
-tr799:
+		lex.act = 68
+		goto st20
+	tr799:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:165
- lex.act = 35;
-	goto st20
-tr802:
+		lex.act = 35
+		goto st20
+	tr802:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:327
- lex.act = 166;
-	goto st20
-tr805:
+		lex.act = 166
+		goto st20
+	tr805:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:150
- lex.act = 24;
-	goto st20
-tr808:
+		lex.act = 24
+		goto st20
+	tr808:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:169
- lex.act = 39;
-	goto st20
+		lex.act = 39
+		goto st20
 	st20:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof20
 		}
 	st_case_20:
 //line lyx/lexer.go:3859
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 95:
 			goto tr57
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -3876,40 +5654,40 @@ tr808:
 		}
 		goto tr0
 	st21:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof21
 		}
 	st_case_21:
-		if  lex.data[( lex.p)] == 46 {
+		if lex.data[(lex.p)] == 46 {
 			goto tr10
 		}
-		if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 			goto st21
 		}
 		goto tr74
 	st22:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof22
 		}
 	st_case_22:
-		if  lex.data[( lex.p)] == 58 {
+		if lex.data[(lex.p)] == 58 {
 			goto tr76
 		}
 		goto tr75
-tr31:
+	tr31:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:383
- lex.act = 210;
-	goto st23
+		lex.act = 210
+		goto st23
 	st23:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof23
 		}
 	st_case_23:
 //line lyx/lexer.go:3912
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 33:
 			goto tr1
 		case 35:
@@ -3936,28 +5714,28 @@ tr31:
 			goto tr1
 		}
 		switch {
-		case  lex.data[( lex.p)] > 38:
-			if 60 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 64 {
+		case lex.data[(lex.p)] > 38:
+			if 60 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
 				goto tr1
 			}
-		case  lex.data[( lex.p)] >= 37:
+		case lex.data[(lex.p)] >= 37:
 			goto tr1
 		}
 		goto tr77
-tr33:
+	tr33:
 //line NONE:1
- lex.te = ( lex.p)+1
+		lex.te = (lex.p) + 1
 
 //line lyx/lexer.rl:384
- lex.act = 211;
-	goto st24
+		lex.act = 211
+		goto st24
 	st24:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof24
 		}
 	st_case_24:
 //line lyx/lexer.go:3960
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 33:
 			goto tr1
 		case 35:
@@ -3982,20 +5760,20 @@ tr33:
 			goto tr1
 		}
 		switch {
-		case  lex.data[( lex.p)] > 38:
-			if 60 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 64 {
+		case lex.data[(lex.p)] > 38:
+			if 60 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 64 {
 				goto tr1
 			}
-		case  lex.data[( lex.p)] >= 37:
+		case lex.data[(lex.p)] >= 37:
 			goto tr1
 		}
 		goto tr80
 	st25:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof25
 		}
 	st_case_25:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -4026,12 +5804,12 @@ tr33:
 			goto tr88
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4039,11 +5817,11 @@ tr33:
 		}
 		goto tr82
 	st26:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof26
 		}
 	st_case_26:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -4054,12 +5832,12 @@ tr33:
 			goto st27
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4067,11 +5845,11 @@ tr33:
 		}
 		goto tr82
 	st27:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof27
 		}
 	st_case_27:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -4082,12 +5860,12 @@ tr33:
 			goto st28
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4095,11 +5873,11 @@ tr33:
 		}
 		goto tr82
 	st28:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof28
 		}
 	st_case_28:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -4110,12 +5888,12 @@ tr33:
 			goto tr91
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4123,11 +5901,11 @@ tr33:
 		}
 		goto tr82
 	st29:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof29
 		}
 	st_case_29:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -4142,12 +5920,12 @@ tr33:
 			goto st30
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4155,11 +5933,11 @@ tr33:
 		}
 		goto tr82
 	st30:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof30
 		}
 	st_case_30:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -4170,12 +5948,12 @@ tr33:
 			goto st31
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4183,11 +5961,11 @@ tr33:
 		}
 		goto tr82
 	st31:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof31
 		}
 	st_case_31:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -4198,12 +5976,12 @@ tr33:
 			goto tr95
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4211,11 +5989,11 @@ tr33:
 		}
 		goto tr82
 	st32:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof32
 		}
 	st_case_32:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -4230,12 +6008,12 @@ tr33:
 			goto tr97
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4243,11 +6021,11 @@ tr33:
 		}
 		goto tr82
 	st33:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof33
 		}
 	st_case_33:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -4258,12 +6036,12 @@ tr33:
 			goto st34
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4271,11 +6049,11 @@ tr33:
 		}
 		goto tr82
 	st34:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof34
 		}
 	st_case_34:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -4286,12 +6064,12 @@ tr33:
 			goto st35
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4299,11 +6077,11 @@ tr33:
 		}
 		goto tr82
 	st35:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof35
 		}
 	st_case_35:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 90:
@@ -4314,12 +6092,12 @@ tr33:
 			goto st36
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 89:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 121 {
+		case lex.data[(lex.p)] > 89:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 121 {
 				goto tr57
 			}
 		default:
@@ -4327,11 +6105,11 @@ tr33:
 		}
 		goto tr82
 	st36:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof36
 		}
 	st_case_36:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -4342,12 +6120,12 @@ tr33:
 			goto tr101
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4355,11 +6133,11 @@ tr33:
 		}
 		goto tr82
 	st37:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof37
 		}
 	st_case_37:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -4370,12 +6148,12 @@ tr33:
 			goto st38
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4383,11 +6161,11 @@ tr33:
 		}
 		goto tr82
 	st38:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof38
 		}
 	st_case_38:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -4398,12 +6176,12 @@ tr33:
 			goto st39
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4411,11 +6189,11 @@ tr33:
 		}
 		goto tr82
 	st39:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof39
 		}
 	st_case_39:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -4426,12 +6204,12 @@ tr33:
 			goto tr104
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4439,11 +6217,11 @@ tr33:
 		}
 		goto tr82
 	st40:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof40
 		}
 	st_case_40:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -4458,12 +6236,12 @@ tr33:
 			goto st41
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4471,11 +6249,11 @@ tr33:
 		}
 		goto tr105
 	st41:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof41
 		}
 	st_case_41:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -4486,12 +6264,12 @@ tr33:
 			goto st42
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4499,11 +6277,11 @@ tr33:
 		}
 		goto tr82
 	st42:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof42
 		}
 	st_case_42:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -4514,12 +6292,12 @@ tr33:
 			goto st43
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4527,11 +6305,11 @@ tr33:
 		}
 		goto tr82
 	st43:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof43
 		}
 	st_case_43:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -4542,12 +6320,12 @@ tr33:
 			goto st44
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4555,11 +6333,11 @@ tr33:
 		}
 		goto tr82
 	st44:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof44
 		}
 	st_case_44:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -4570,12 +6348,12 @@ tr33:
 			goto st45
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4583,11 +6361,11 @@ tr33:
 		}
 		goto tr82
 	st45:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof45
 		}
 	st_case_45:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -4598,12 +6376,12 @@ tr33:
 			goto st46
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4611,11 +6389,11 @@ tr33:
 		}
 		goto tr82
 	st46:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof46
 		}
 	st_case_46:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -4626,12 +6404,12 @@ tr33:
 			goto st47
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4639,11 +6417,11 @@ tr33:
 		}
 		goto tr82
 	st47:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof47
 		}
 	st_case_47:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -4654,12 +6432,12 @@ tr33:
 			goto tr114
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4667,11 +6445,11 @@ tr33:
 		}
 		goto tr82
 	st48:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof48
 		}
 	st_case_48:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -4698,12 +6476,12 @@ tr33:
 			goto tr119
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4711,11 +6489,11 @@ tr33:
 		}
 		goto tr82
 	st49:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof49
 		}
 	st_case_49:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -4730,12 +6508,12 @@ tr33:
 			goto st52
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4743,11 +6521,11 @@ tr33:
 		}
 		goto tr82
 	st50:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof50
 		}
 	st_case_50:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -4758,12 +6536,12 @@ tr33:
 			goto st51
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4771,11 +6549,11 @@ tr33:
 		}
 		goto tr82
 	st51:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof51
 		}
 	st_case_51:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -4786,12 +6564,12 @@ tr33:
 			goto tr123
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4799,11 +6577,11 @@ tr33:
 		}
 		goto tr82
 	st52:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof52
 		}
 	st_case_52:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 87:
@@ -4814,12 +6592,12 @@ tr33:
 			goto st53
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4827,11 +6605,11 @@ tr33:
 		}
 		goto tr82
 	st53:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof53
 		}
 	st_case_53:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -4842,12 +6620,12 @@ tr33:
 			goto st54
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4855,11 +6633,11 @@ tr33:
 		}
 		goto tr82
 	st54:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof54
 		}
 	st_case_54:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -4870,12 +6648,12 @@ tr33:
 			goto st55
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4883,11 +6661,11 @@ tr33:
 		}
 		goto tr82
 	st55:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof55
 		}
 	st_case_55:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -4898,12 +6676,12 @@ tr33:
 			goto tr127
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4911,11 +6689,11 @@ tr33:
 		}
 		goto tr82
 	st56:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof56
 		}
 	st_case_56:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -4934,12 +6712,12 @@ tr33:
 			goto tr130
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4947,11 +6725,11 @@ tr33:
 		}
 		goto tr82
 	st57:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof57
 		}
 	st_case_57:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -4962,12 +6740,12 @@ tr33:
 			goto st58
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -4975,11 +6753,11 @@ tr33:
 		}
 		goto tr82
 	st58:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof58
 		}
 	st_case_58:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -4990,12 +6768,12 @@ tr33:
 			goto st59
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5003,11 +6781,11 @@ tr33:
 		}
 		goto tr82
 	st59:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof59
 		}
 	st_case_59:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -5018,12 +6796,12 @@ tr33:
 			goto tr133
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5031,11 +6809,11 @@ tr33:
 		}
 		goto tr82
 	st60:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof60
 		}
 	st_case_60:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -5046,12 +6824,12 @@ tr33:
 			goto st61
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5059,11 +6837,11 @@ tr33:
 		}
 		goto tr82
 	st61:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof61
 		}
 	st_case_61:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -5074,12 +6852,12 @@ tr33:
 			goto st62
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5087,11 +6865,11 @@ tr33:
 		}
 		goto tr82
 	st62:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof62
 		}
 	st_case_62:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -5102,12 +6880,12 @@ tr33:
 			goto tr136
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5115,11 +6893,11 @@ tr33:
 		}
 		goto tr82
 	st63:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof63
 		}
 	st_case_63:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -5130,12 +6908,12 @@ tr33:
 			goto st64
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5143,11 +6921,11 @@ tr33:
 		}
 		goto tr82
 	st64:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof64
 		}
 	st_case_64:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -5158,12 +6936,12 @@ tr33:
 			goto st65
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5171,11 +6949,11 @@ tr33:
 		}
 		goto tr82
 	st65:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof65
 		}
 	st_case_65:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -5186,12 +6964,12 @@ tr33:
 			goto st66
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5199,11 +6977,11 @@ tr33:
 		}
 		goto tr82
 	st66:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof66
 		}
 	st_case_66:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -5214,12 +6992,12 @@ tr33:
 			goto st67
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5227,11 +7005,11 @@ tr33:
 		}
 		goto tr82
 	st67:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof67
 		}
 	st_case_67:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -5242,12 +7020,12 @@ tr33:
 			goto tr141
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5255,11 +7033,11 @@ tr33:
 		}
 		goto tr82
 	st68:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof68
 		}
 	st_case_68:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -5270,12 +7048,12 @@ tr33:
 			goto st69
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5283,11 +7061,11 @@ tr33:
 		}
 		goto tr82
 	st69:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof69
 		}
 	st_case_69:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -5298,12 +7076,12 @@ tr33:
 			goto st70
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5311,11 +7089,11 @@ tr33:
 		}
 		goto tr82
 	st70:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof70
 		}
 	st_case_70:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -5326,12 +7104,12 @@ tr33:
 			goto st71
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5339,11 +7117,11 @@ tr33:
 		}
 		goto tr82
 	st71:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof71
 		}
 	st_case_71:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -5354,12 +7132,12 @@ tr33:
 			goto st72
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5367,11 +7145,11 @@ tr33:
 		}
 		goto tr82
 	st72:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof72
 		}
 	st_case_72:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -5382,12 +7160,12 @@ tr33:
 			goto tr146
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5395,11 +7173,11 @@ tr33:
 		}
 		goto tr82
 	st73:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof73
 		}
 	st_case_73:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -5438,12 +7216,12 @@ tr33:
 			goto st135
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5451,11 +7229,11 @@ tr33:
 		}
 		goto tr82
 	st74:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof74
 		}
 	st_case_74:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -5466,12 +7244,12 @@ tr33:
 			goto st75
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5479,11 +7257,11 @@ tr33:
 		}
 		goto tr82
 	st75:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof75
 		}
 	st_case_75:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -5502,12 +7280,12 @@ tr33:
 			goto tr158
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5515,11 +7293,11 @@ tr33:
 		}
 		goto tr82
 	st76:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof76
 		}
 	st_case_76:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -5530,12 +7308,12 @@ tr33:
 			goto st77
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5543,11 +7321,11 @@ tr33:
 		}
 		goto tr82
 	st77:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof77
 		}
 	st_case_77:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -5558,12 +7336,12 @@ tr33:
 			goto st78
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5571,11 +7349,11 @@ tr33:
 		}
 		goto tr82
 	st78:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof78
 		}
 	st_case_78:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -5586,12 +7364,12 @@ tr33:
 			goto tr161
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5599,11 +7377,11 @@ tr33:
 		}
 		goto tr82
 	st79:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof79
 		}
 	st_case_79:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -5618,12 +7396,12 @@ tr33:
 			goto st92
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5631,11 +7409,11 @@ tr33:
 		}
 		goto tr82
 	st80:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof80
 		}
 	st_case_80:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -5646,12 +7424,12 @@ tr33:
 			goto st81
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5659,11 +7437,11 @@ tr33:
 		}
 		goto tr82
 	st81:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof81
 		}
 	st_case_81:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -5674,12 +7452,12 @@ tr33:
 			goto st82
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5687,11 +7465,11 @@ tr33:
 		}
 		goto tr165
 	st82:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof82
 		}
 	st_case_82:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -5702,12 +7480,12 @@ tr33:
 			goto st83
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5715,11 +7493,11 @@ tr33:
 		}
 		goto tr82
 	st83:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof83
 		}
 	st_case_83:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -5730,12 +7508,12 @@ tr33:
 			goto st84
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5743,11 +7521,11 @@ tr33:
 		}
 		goto tr82
 	st84:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof84
 		}
 	st_case_84:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -5758,12 +7536,12 @@ tr33:
 			goto st85
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5771,11 +7549,11 @@ tr33:
 		}
 		goto tr82
 	st85:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof85
 		}
 	st_case_85:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -5786,12 +7564,12 @@ tr33:
 			goto st86
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5799,11 +7577,11 @@ tr33:
 		}
 		goto tr82
 	st86:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof86
 		}
 	st_case_86:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -5814,12 +7592,12 @@ tr33:
 			goto st87
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5827,11 +7605,11 @@ tr33:
 		}
 		goto tr171
 	st87:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof87
 		}
 	st_case_87:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -5842,12 +7620,12 @@ tr33:
 			goto st88
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5855,11 +7633,11 @@ tr33:
 		}
 		goto tr82
 	st88:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof88
 		}
 	st_case_88:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -5870,12 +7648,12 @@ tr33:
 			goto st89
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5883,11 +7661,11 @@ tr33:
 		}
 		goto tr82
 	st89:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof89
 		}
 	st_case_89:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -5898,12 +7676,12 @@ tr33:
 			goto st90
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5911,11 +7689,11 @@ tr33:
 		}
 		goto tr82
 	st90:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof90
 		}
 	st_case_90:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -5926,12 +7704,12 @@ tr33:
 			goto st91
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5939,11 +7717,11 @@ tr33:
 		}
 		goto tr82
 	st91:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof91
 		}
 	st_case_91:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -5954,12 +7732,12 @@ tr33:
 			goto tr177
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5967,11 +7745,11 @@ tr33:
 		}
 		goto tr82
 	st92:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof92
 		}
 	st_case_92:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -5982,12 +7760,12 @@ tr33:
 			goto st93
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -5995,11 +7773,11 @@ tr33:
 		}
 		goto tr82
 	st93:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof93
 		}
 	st_case_93:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 75:
@@ -6010,12 +7788,12 @@ tr33:
 			goto tr179
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6023,11 +7801,11 @@ tr33:
 		}
 		goto tr82
 	st94:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof94
 		}
 	st_case_94:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -6038,12 +7816,12 @@ tr33:
 			goto st95
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6051,11 +7829,11 @@ tr33:
 		}
 		goto tr82
 	st95:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof95
 		}
 	st_case_95:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -6066,12 +7844,12 @@ tr33:
 			goto st96
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6079,11 +7857,11 @@ tr33:
 		}
 		goto tr82
 	st96:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof96
 		}
 	st_case_96:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -6094,12 +7872,12 @@ tr33:
 			goto st97
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6107,11 +7885,11 @@ tr33:
 		}
 		goto tr82
 	st97:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof97
 		}
 	st_case_97:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -6122,12 +7900,12 @@ tr33:
 			goto st98
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6135,11 +7913,11 @@ tr33:
 		}
 		goto tr82
 	st98:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof98
 		}
 	st_case_98:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -6150,12 +7928,12 @@ tr33:
 			goto tr184
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6163,11 +7941,11 @@ tr33:
 		}
 		goto tr82
 	st99:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof99
 		}
 	st_case_99:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -6186,12 +7964,12 @@ tr33:
 			goto st117
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6199,11 +7977,11 @@ tr33:
 		}
 		goto tr82
 	st100:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof100
 		}
 	st_case_100:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -6214,12 +7992,12 @@ tr33:
 			goto st101
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6227,11 +8005,11 @@ tr33:
 		}
 		goto tr82
 	st101:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof101
 		}
 	st_case_101:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -6242,12 +8020,12 @@ tr33:
 			goto st102
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6255,11 +8033,11 @@ tr33:
 		}
 		goto tr82
 	st102:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof102
 		}
 	st_case_102:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -6270,12 +8048,12 @@ tr33:
 			goto st103
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6283,11 +8061,11 @@ tr33:
 		}
 		goto tr82
 	st103:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof103
 		}
 	st_case_103:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -6298,12 +8076,12 @@ tr33:
 			goto st104
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6311,11 +8089,11 @@ tr33:
 		}
 		goto tr191
 	st104:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof104
 		}
 	st_case_104:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -6326,12 +8104,12 @@ tr33:
 			goto st105
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6339,11 +8117,11 @@ tr33:
 		}
 		goto tr82
 	st105:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof105
 		}
 	st_case_105:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -6354,12 +8132,12 @@ tr33:
 			goto tr194
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6367,11 +8145,11 @@ tr33:
 		}
 		goto tr82
 	st106:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof106
 		}
 	st_case_106:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 70:
@@ -6386,12 +8164,12 @@ tr33:
 			goto st111
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6399,11 +8177,11 @@ tr33:
 		}
 		goto tr82
 	st107:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof107
 		}
 	st_case_107:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -6414,12 +8192,12 @@ tr33:
 			goto st108
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6427,11 +8205,11 @@ tr33:
 		}
 		goto tr82
 	st108:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof108
 		}
 	st_case_108:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -6442,12 +8220,12 @@ tr33:
 			goto st109
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6455,11 +8233,11 @@ tr33:
 		}
 		goto tr82
 	st109:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof109
 		}
 	st_case_109:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -6470,12 +8248,12 @@ tr33:
 			goto st110
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6483,11 +8261,11 @@ tr33:
 		}
 		goto tr82
 	st110:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof110
 		}
 	st_case_110:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -6498,12 +8276,12 @@ tr33:
 			goto tr200
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6511,11 +8289,11 @@ tr33:
 		}
 		goto tr82
 	st111:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof111
 		}
 	st_case_111:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -6526,12 +8304,12 @@ tr33:
 			goto st112
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6539,11 +8317,11 @@ tr33:
 		}
 		goto tr82
 	st112:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof112
 		}
 	st_case_112:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -6554,12 +8332,12 @@ tr33:
 			goto st113
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6567,11 +8345,11 @@ tr33:
 		}
 		goto tr82
 	st113:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof113
 		}
 	st_case_113:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -6582,12 +8360,12 @@ tr33:
 			goto st114
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6595,11 +8373,11 @@ tr33:
 		}
 		goto tr82
 	st114:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof114
 		}
 	st_case_114:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -6610,12 +8388,12 @@ tr33:
 			goto st115
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6623,11 +8401,11 @@ tr33:
 		}
 		goto tr82
 	st115:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof115
 		}
 	st_case_115:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -6638,12 +8416,12 @@ tr33:
 			goto st116
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6651,11 +8429,11 @@ tr33:
 		}
 		goto tr82
 	st116:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof116
 		}
 	st_case_116:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -6666,12 +8444,12 @@ tr33:
 			goto tr206
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6679,11 +8457,11 @@ tr33:
 		}
 		goto tr82
 	st117:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof117
 		}
 	st_case_117:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -6694,12 +8472,12 @@ tr33:
 			goto tr207
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6707,11 +8485,11 @@ tr33:
 		}
 		goto tr82
 	st118:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof118
 		}
 	st_case_118:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -6726,12 +8504,12 @@ tr33:
 			goto st122
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6739,11 +8517,11 @@ tr33:
 		}
 		goto tr82
 	st119:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof119
 		}
 	st_case_119:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -6754,12 +8532,12 @@ tr33:
 			goto st120
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6767,11 +8545,11 @@ tr33:
 		}
 		goto tr82
 	st120:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof120
 		}
 	st_case_120:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -6782,12 +8560,12 @@ tr33:
 			goto st121
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6795,11 +8573,11 @@ tr33:
 		}
 		goto tr82
 	st121:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof121
 		}
 	st_case_121:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -6810,12 +8588,12 @@ tr33:
 			goto tr212
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6823,11 +8601,11 @@ tr33:
 		}
 		goto tr82
 	st122:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof122
 		}
 	st_case_122:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -6838,12 +8616,12 @@ tr33:
 			goto st123
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6851,11 +8629,11 @@ tr33:
 		}
 		goto tr82
 	st123:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof123
 		}
 	st_case_123:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -6866,12 +8644,12 @@ tr33:
 			goto tr214
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6879,11 +8657,11 @@ tr33:
 		}
 		goto tr82
 	st124:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof124
 		}
 	st_case_124:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 86:
@@ -6894,12 +8672,12 @@ tr33:
 			goto tr215
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6907,11 +8685,11 @@ tr33:
 		}
 		goto tr82
 	st125:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof125
 		}
 	st_case_125:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -6922,12 +8700,12 @@ tr33:
 			goto st126
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6935,11 +8713,11 @@ tr33:
 		}
 		goto tr82
 	st126:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof126
 		}
 	st_case_126:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -6950,12 +8728,12 @@ tr33:
 			goto st127
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6963,11 +8741,11 @@ tr33:
 		}
 		goto tr82
 	st127:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof127
 		}
 	st_case_127:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -6978,12 +8756,12 @@ tr33:
 			goto st128
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -6991,11 +8769,11 @@ tr33:
 		}
 		goto tr82
 	st128:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof128
 		}
 	st_case_128:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -7006,12 +8784,12 @@ tr33:
 			goto st129
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7019,11 +8797,11 @@ tr33:
 		}
 		goto tr82
 	st129:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof129
 		}
 	st_case_129:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -7034,12 +8812,12 @@ tr33:
 			goto st130
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7047,23 +8825,23 @@ tr33:
 		}
 		goto tr82
 	st130:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof130
 		}
 	st_case_130:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 95:
 			goto st131
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7071,11 +8849,11 @@ tr33:
 		}
 		goto tr82
 	st131:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof131
 		}
 	st_case_131:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -7086,12 +8864,12 @@ tr33:
 			goto st132
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7099,11 +8877,11 @@ tr33:
 		}
 		goto tr82
 	st132:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof132
 		}
 	st_case_132:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -7114,12 +8892,12 @@ tr33:
 			goto st133
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7127,11 +8905,11 @@ tr33:
 		}
 		goto tr82
 	st133:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof133
 		}
 	st_case_133:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -7142,12 +8920,12 @@ tr33:
 			goto st134
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7155,11 +8933,11 @@ tr33:
 		}
 		goto tr82
 	st134:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof134
 		}
 	st_case_134:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -7170,12 +8948,12 @@ tr33:
 			goto tr225
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7183,11 +8961,11 @@ tr33:
 		}
 		goto tr82
 	st135:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof135
 		}
 	st_case_135:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -7198,12 +8976,12 @@ tr33:
 			goto st136
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7211,11 +8989,11 @@ tr33:
 		}
 		goto tr82
 	st136:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof136
 		}
 	st_case_136:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -7226,12 +9004,12 @@ tr33:
 			goto st137
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7239,11 +9017,11 @@ tr33:
 		}
 		goto tr82
 	st137:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof137
 		}
 	st_case_137:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -7254,12 +9032,12 @@ tr33:
 			goto tr228
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7267,11 +9045,11 @@ tr33:
 		}
 		goto tr82
 	st138:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof138
 		}
 	st_case_138:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -7298,12 +9076,12 @@ tr33:
 			goto st192
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7311,11 +9089,11 @@ tr33:
 		}
 		goto tr82
 	st139:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof139
 		}
 	st_case_139:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -7330,12 +9108,12 @@ tr33:
 			goto tr235
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7343,11 +9121,11 @@ tr33:
 		}
 		goto tr82
 	st140:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof140
 		}
 	st_case_140:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -7358,12 +9136,12 @@ tr33:
 			goto st141
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7371,11 +9149,11 @@ tr33:
 		}
 		goto tr82
 	st141:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof141
 		}
 	st_case_141:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -7386,12 +9164,12 @@ tr33:
 			goto st142
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7399,11 +9177,11 @@ tr33:
 		}
 		goto tr82
 	st142:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof142
 		}
 	st_case_142:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -7414,12 +9192,12 @@ tr33:
 			goto st143
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7427,11 +9205,11 @@ tr33:
 		}
 		goto tr82
 	st143:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof143
 		}
 	st_case_143:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -7442,12 +9220,12 @@ tr33:
 			goto st144
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7455,11 +9233,11 @@ tr33:
 		}
 		goto tr82
 	st144:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof144
 		}
 	st_case_144:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -7470,12 +9248,12 @@ tr33:
 			goto tr240
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7483,11 +9261,11 @@ tr33:
 		}
 		goto tr82
 	st145:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof145
 		}
 	st_case_145:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -7518,12 +9296,12 @@ tr33:
 			goto st178
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7531,11 +9309,11 @@ tr33:
 		}
 		goto tr82
 	st146:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof146
 		}
 	st_case_146:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -7546,12 +9324,12 @@ tr33:
 			goto st147
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7559,11 +9337,11 @@ tr33:
 		}
 		goto tr82
 	st147:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof147
 		}
 	st_case_147:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -7574,12 +9352,12 @@ tr33:
 			goto st148
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7587,11 +9365,11 @@ tr33:
 		}
 		goto tr82
 	st148:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof148
 		}
 	st_case_148:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -7602,12 +9380,12 @@ tr33:
 			goto st149
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7615,11 +9393,11 @@ tr33:
 		}
 		goto tr82
 	st149:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof149
 		}
 	st_case_149:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -7630,12 +9408,12 @@ tr33:
 			goto st150
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7643,11 +9421,11 @@ tr33:
 		}
 		goto tr82
 	st150:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof150
 		}
 	st_case_150:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -7658,12 +9436,12 @@ tr33:
 			goto st151
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7671,11 +9449,11 @@ tr33:
 		}
 		goto tr82
 	st151:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof151
 		}
 	st_case_151:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -7686,12 +9464,12 @@ tr33:
 			goto st152
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7699,11 +9477,11 @@ tr33:
 		}
 		goto tr82
 	st152:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof152
 		}
 	st_case_152:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -7714,12 +9492,12 @@ tr33:
 			goto tr253
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7727,11 +9505,11 @@ tr33:
 		}
 		goto tr82
 	st153:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof153
 		}
 	st_case_153:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -7742,12 +9520,12 @@ tr33:
 			goto st154
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7755,11 +9533,11 @@ tr33:
 		}
 		goto tr254
 	st154:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof154
 		}
 	st_case_154:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -7770,12 +9548,12 @@ tr33:
 			goto st155
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7783,11 +9561,11 @@ tr33:
 		}
 		goto tr82
 	st155:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof155
 		}
 	st_case_155:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -7798,12 +9576,12 @@ tr33:
 			goto st156
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7811,11 +9589,11 @@ tr33:
 		}
 		goto tr82
 	st156:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof156
 		}
 	st_case_156:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -7826,12 +9604,12 @@ tr33:
 			goto tr258
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7839,11 +9617,11 @@ tr33:
 		}
 		goto tr82
 	st157:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof157
 		}
 	st_case_157:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -7858,12 +9636,12 @@ tr33:
 			goto st161
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7871,11 +9649,11 @@ tr33:
 		}
 		goto tr82
 	st158:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof158
 		}
 	st_case_158:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -7886,12 +9664,12 @@ tr33:
 			goto st159
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7899,11 +9677,11 @@ tr33:
 		}
 		goto tr82
 	st159:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof159
 		}
 	st_case_159:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -7914,12 +9692,12 @@ tr33:
 			goto st160
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7927,11 +9705,11 @@ tr33:
 		}
 		goto tr82
 	st160:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof160
 		}
 	st_case_160:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -7942,12 +9720,12 @@ tr33:
 			goto tr263
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7955,11 +9733,11 @@ tr33:
 		}
 		goto tr82
 	st161:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof161
 		}
 	st_case_161:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -7970,12 +9748,12 @@ tr33:
 			goto st162
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -7983,11 +9761,11 @@ tr33:
 		}
 		goto tr82
 	st162:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof162
 		}
 	st_case_162:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -7998,12 +9776,12 @@ tr33:
 			goto st163
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8011,11 +9789,11 @@ tr33:
 		}
 		goto tr82
 	st163:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof163
 		}
 	st_case_163:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -8026,12 +9804,12 @@ tr33:
 			goto st164
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8039,11 +9817,11 @@ tr33:
 		}
 		goto tr82
 	st164:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof164
 		}
 	st_case_164:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -8054,12 +9832,12 @@ tr33:
 			goto st165
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8067,11 +9845,11 @@ tr33:
 		}
 		goto tr82
 	st165:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof165
 		}
 	st_case_165:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -8082,12 +9860,12 @@ tr33:
 			goto st166
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8095,11 +9873,11 @@ tr33:
 		}
 		goto tr82
 	st166:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof166
 		}
 	st_case_166:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -8110,12 +9888,12 @@ tr33:
 			goto tr269
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8123,11 +9901,11 @@ tr33:
 		}
 		goto tr82
 	st167:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof167
 		}
 	st_case_167:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -8142,12 +9920,12 @@ tr33:
 			goto st170
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8155,11 +9933,11 @@ tr33:
 		}
 		goto tr82
 	st168:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof168
 		}
 	st_case_168:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -8170,12 +9948,12 @@ tr33:
 			goto st169
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8183,11 +9961,11 @@ tr33:
 		}
 		goto tr82
 	st169:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof169
 		}
 	st_case_169:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -8198,12 +9976,12 @@ tr33:
 			goto tr273
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8211,11 +9989,11 @@ tr33:
 		}
 		goto tr82
 	st170:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof170
 		}
 	st_case_170:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -8226,12 +10004,12 @@ tr33:
 			goto st171
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8239,11 +10017,11 @@ tr33:
 		}
 		goto tr82
 	st171:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof171
 		}
 	st_case_171:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -8254,12 +10032,12 @@ tr33:
 			goto st172
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8267,11 +10045,11 @@ tr33:
 		}
 		goto tr82
 	st172:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof172
 		}
 	st_case_172:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -8282,12 +10060,12 @@ tr33:
 			goto st173
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8295,11 +10073,11 @@ tr33:
 		}
 		goto tr82
 	st173:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof173
 		}
 	st_case_173:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -8310,12 +10088,12 @@ tr33:
 			goto st174
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8323,11 +10101,11 @@ tr33:
 		}
 		goto tr82
 	st174:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof174
 		}
 	st_case_174:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -8338,12 +10116,12 @@ tr33:
 			goto st175
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8351,11 +10129,11 @@ tr33:
 		}
 		goto tr82
 	st175:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof175
 		}
 	st_case_175:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -8366,12 +10144,12 @@ tr33:
 			goto tr280
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8379,11 +10157,11 @@ tr33:
 		}
 		goto tr279
 	st176:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof176
 		}
 	st_case_176:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -8394,12 +10172,12 @@ tr33:
 			goto st177
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8407,11 +10185,11 @@ tr33:
 		}
 		goto tr82
 	st177:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof177
 		}
 	st_case_177:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -8422,12 +10200,12 @@ tr33:
 			goto tr282
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8435,11 +10213,11 @@ tr33:
 		}
 		goto tr82
 	st178:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof178
 		}
 	st_case_178:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -8450,12 +10228,12 @@ tr33:
 			goto tr283
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8463,11 +10241,11 @@ tr33:
 		}
 		goto tr82
 	st179:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof179
 		}
 	st_case_179:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -8478,12 +10256,12 @@ tr33:
 			goto st180
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8491,11 +10269,11 @@ tr33:
 		}
 		goto tr82
 	st180:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof180
 		}
 	st_case_180:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -8510,12 +10288,12 @@ tr33:
 			goto st184
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8523,11 +10301,11 @@ tr33:
 		}
 		goto tr82
 	st181:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof181
 		}
 	st_case_181:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -8538,12 +10316,12 @@ tr33:
 			goto st182
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8551,11 +10329,11 @@ tr33:
 		}
 		goto tr82
 	st182:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof182
 		}
 	st_case_182:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -8566,12 +10344,12 @@ tr33:
 			goto st183
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8579,11 +10357,11 @@ tr33:
 		}
 		goto tr82
 	st183:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof183
 		}
 	st_case_183:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -8594,12 +10372,12 @@ tr33:
 			goto tr289
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8607,11 +10385,11 @@ tr33:
 		}
 		goto tr82
 	st184:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof184
 		}
 	st_case_184:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -8622,12 +10400,12 @@ tr33:
 			goto st185
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8635,11 +10413,11 @@ tr33:
 		}
 		goto tr82
 	st185:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof185
 		}
 	st_case_185:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -8650,12 +10428,12 @@ tr33:
 			goto st186
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8663,11 +10441,11 @@ tr33:
 		}
 		goto tr82
 	st186:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof186
 		}
 	st_case_186:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -8678,12 +10456,12 @@ tr33:
 			goto st187
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8691,11 +10469,11 @@ tr33:
 		}
 		goto tr82
 	st187:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof187
 		}
 	st_case_187:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -8706,12 +10484,12 @@ tr33:
 			goto tr293
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8719,11 +10497,11 @@ tr33:
 		}
 		goto tr82
 	st188:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof188
 		}
 	st_case_188:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -8734,12 +10512,12 @@ tr33:
 			goto st189
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8747,11 +10525,11 @@ tr33:
 		}
 		goto tr294
 	st189:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof189
 		}
 	st_case_189:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -8762,12 +10540,12 @@ tr33:
 			goto st190
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8775,11 +10553,11 @@ tr33:
 		}
 		goto tr82
 	st190:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof190
 		}
 	st_case_190:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -8790,12 +10568,12 @@ tr33:
 			goto st191
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8803,11 +10581,11 @@ tr33:
 		}
 		goto tr82
 	st191:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof191
 		}
 	st_case_191:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -8818,12 +10596,12 @@ tr33:
 			goto tr298
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8831,11 +10609,11 @@ tr33:
 		}
 		goto tr82
 	st192:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof192
 		}
 	st_case_192:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -8846,12 +10624,12 @@ tr33:
 			goto st193
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8859,11 +10637,11 @@ tr33:
 		}
 		goto tr82
 	st193:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof193
 		}
 	st_case_193:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 80:
@@ -8874,12 +10652,12 @@ tr33:
 			goto tr300
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8887,11 +10665,11 @@ tr33:
 		}
 		goto tr82
 	st194:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof194
 		}
 	st_case_194:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -8914,12 +10692,12 @@ tr33:
 			goto st208
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8927,11 +10705,11 @@ tr33:
 		}
 		goto tr82
 	st195:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof195
 		}
 	st_case_195:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -8942,12 +10720,12 @@ tr33:
 			goto st196
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8955,11 +10733,11 @@ tr33:
 		}
 		goto tr82
 	st196:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof196
 		}
 	st_case_196:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -8970,12 +10748,12 @@ tr33:
 			goto tr306
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -8983,11 +10761,11 @@ tr33:
 		}
 		goto tr82
 	st197:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof197
 		}
 	st_case_197:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -9006,12 +10784,12 @@ tr33:
 			goto st203
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9019,11 +10797,11 @@ tr33:
 		}
 		goto tr82
 	st198:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof198
 		}
 	st_case_198:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -9034,12 +10812,12 @@ tr33:
 			goto st199
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9047,11 +10825,11 @@ tr33:
 		}
 		goto tr82
 	st199:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof199
 		}
 	st_case_199:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -9062,12 +10840,12 @@ tr33:
 			goto st200
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9075,11 +10853,11 @@ tr33:
 		}
 		goto tr82
 	st200:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof200
 		}
 	st_case_200:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -9090,12 +10868,12 @@ tr33:
 			goto st201
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9103,11 +10881,11 @@ tr33:
 		}
 		goto tr82
 	st201:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof201
 		}
 	st_case_201:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -9118,12 +10896,12 @@ tr33:
 			goto st202
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9131,11 +10909,11 @@ tr33:
 		}
 		goto tr82
 	st202:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof202
 		}
 	st_case_202:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -9146,12 +10924,12 @@ tr33:
 			goto tr314
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9159,11 +10937,11 @@ tr33:
 		}
 		goto tr82
 	st203:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof203
 		}
 	st_case_203:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -9174,12 +10952,12 @@ tr33:
 			goto tr315
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9187,11 +10965,11 @@ tr33:
 		}
 		goto tr82
 	st204:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof204
 		}
 	st_case_204:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -9202,12 +10980,12 @@ tr33:
 			goto st205
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9215,11 +10993,11 @@ tr33:
 		}
 		goto tr82
 	st205:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof205
 		}
 	st_case_205:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -9230,12 +11008,12 @@ tr33:
 			goto st206
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9243,11 +11021,11 @@ tr33:
 		}
 		goto tr82
 	st206:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof206
 		}
 	st_case_206:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 80:
@@ -9258,12 +11036,12 @@ tr33:
 			goto st207
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9271,11 +11049,11 @@ tr33:
 		}
 		goto tr82
 	st207:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof207
 		}
 	st_case_207:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -9286,12 +11064,12 @@ tr33:
 			goto tr319
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9299,11 +11077,11 @@ tr33:
 		}
 		goto tr82
 	st208:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof208
 		}
 	st_case_208:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -9330,12 +11108,12 @@ tr33:
 			goto st223
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9343,11 +11121,11 @@ tr33:
 		}
 		goto tr82
 	st209:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof209
 		}
 	st_case_209:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -9358,12 +11136,12 @@ tr33:
 			goto st210
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9371,11 +11149,11 @@ tr33:
 		}
 		goto tr82
 	st210:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof210
 		}
 	st_case_210:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 80:
@@ -9386,12 +11164,12 @@ tr33:
 			goto st211
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9399,11 +11177,11 @@ tr33:
 		}
 		goto tr82
 	st211:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof211
 		}
 	st_case_211:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -9414,12 +11192,12 @@ tr33:
 			goto tr327
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9427,11 +11205,11 @@ tr33:
 		}
 		goto tr82
 	st212:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof212
 		}
 	st_case_212:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -9442,12 +11220,12 @@ tr33:
 			goto st213
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9455,11 +11233,11 @@ tr33:
 		}
 		goto tr82
 	st213:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof213
 		}
 	st_case_213:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -9470,12 +11248,12 @@ tr33:
 			goto st214
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9483,11 +11261,11 @@ tr33:
 		}
 		goto tr82
 	st214:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof214
 		}
 	st_case_214:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -9498,12 +11276,12 @@ tr33:
 			goto st215
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9511,11 +11289,11 @@ tr33:
 		}
 		goto tr82
 	st215:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof215
 		}
 	st_case_215:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -9526,12 +11304,12 @@ tr33:
 			goto tr331
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9539,11 +11317,11 @@ tr33:
 		}
 		goto tr82
 	st216:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof216
 		}
 	st_case_216:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -9554,12 +11332,12 @@ tr33:
 			goto st217
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9567,11 +11345,11 @@ tr33:
 		}
 		goto tr82
 	st217:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof217
 		}
 	st_case_217:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -9582,12 +11360,12 @@ tr33:
 			goto st218
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9595,11 +11373,11 @@ tr33:
 		}
 		goto tr82
 	st218:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof218
 		}
 	st_case_218:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -9610,12 +11388,12 @@ tr33:
 			goto tr334
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9623,11 +11401,11 @@ tr33:
 		}
 		goto tr82
 	st219:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof219
 		}
 	st_case_219:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -9638,12 +11416,12 @@ tr33:
 			goto st220
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9651,11 +11429,11 @@ tr33:
 		}
 		goto tr82
 	st220:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof220
 		}
 	st_case_220:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -9666,12 +11444,12 @@ tr33:
 			goto st221
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9679,11 +11457,11 @@ tr33:
 		}
 		goto tr82
 	st221:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof221
 		}
 	st_case_221:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -9694,12 +11472,12 @@ tr33:
 			goto st222
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9707,11 +11485,11 @@ tr33:
 		}
 		goto tr82
 	st222:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof222
 		}
 	st_case_222:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -9722,12 +11500,12 @@ tr33:
 			goto tr338
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9735,11 +11513,11 @@ tr33:
 		}
 		goto tr82
 	st223:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof223
 		}
 	st_case_223:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -9754,12 +11532,12 @@ tr33:
 			goto st229
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9767,11 +11545,11 @@ tr33:
 		}
 		goto tr82
 	st224:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof224
 		}
 	st_case_224:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -9782,12 +11560,12 @@ tr33:
 			goto st225
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9795,11 +11573,11 @@ tr33:
 		}
 		goto tr82
 	st225:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof225
 		}
 	st_case_225:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -9810,12 +11588,12 @@ tr33:
 			goto st226
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9823,11 +11601,11 @@ tr33:
 		}
 		goto tr82
 	st226:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof226
 		}
 	st_case_226:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -9838,12 +11616,12 @@ tr33:
 			goto st227
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9851,11 +11629,11 @@ tr33:
 		}
 		goto tr82
 	st227:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof227
 		}
 	st_case_227:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -9866,12 +11644,12 @@ tr33:
 			goto st228
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9879,11 +11657,11 @@ tr33:
 		}
 		goto tr82
 	st228:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof228
 		}
 	st_case_228:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -9894,12 +11672,12 @@ tr33:
 			goto tr345
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9907,11 +11685,11 @@ tr33:
 		}
 		goto tr82
 	st229:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof229
 		}
 	st_case_229:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -9922,12 +11700,12 @@ tr33:
 			goto st230
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9935,11 +11713,11 @@ tr33:
 		}
 		goto tr82
 	st230:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof230
 		}
 	st_case_230:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -9950,12 +11728,12 @@ tr33:
 			goto st231
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9963,11 +11741,11 @@ tr33:
 		}
 		goto tr82
 	st231:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof231
 		}
 	st_case_231:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -9978,12 +11756,12 @@ tr33:
 			goto tr348
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -9991,11 +11769,11 @@ tr33:
 		}
 		goto tr82
 	st232:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof232
 		}
 	st_case_232:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -10026,12 +11804,12 @@ tr33:
 			goto st252
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10039,11 +11817,11 @@ tr33:
 		}
 		goto tr82
 	st233:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof233
 		}
 	st_case_233:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -10054,12 +11832,12 @@ tr33:
 			goto st234
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10067,11 +11845,11 @@ tr33:
 		}
 		goto tr82
 	st234:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof234
 		}
 	st_case_234:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -10082,12 +11860,12 @@ tr33:
 			goto st235
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10095,11 +11873,11 @@ tr33:
 		}
 		goto tr82
 	st235:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof235
 		}
 	st_case_235:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -10110,12 +11888,12 @@ tr33:
 			goto tr357
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10123,11 +11901,11 @@ tr33:
 		}
 		goto tr82
 	st236:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof236
 		}
 	st_case_236:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -10142,12 +11920,12 @@ tr33:
 			goto st240
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10155,11 +11933,11 @@ tr33:
 		}
 		goto tr82
 	st237:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof237
 		}
 	st_case_237:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -10170,12 +11948,12 @@ tr33:
 			goto st238
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10183,11 +11961,11 @@ tr33:
 		}
 		goto tr82
 	st238:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof238
 		}
 	st_case_238:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -10198,12 +11976,12 @@ tr33:
 			goto st239
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10211,11 +11989,11 @@ tr33:
 		}
 		goto tr82
 	st239:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof239
 		}
 	st_case_239:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -10226,12 +12004,12 @@ tr33:
 			goto tr362
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10239,11 +12017,11 @@ tr33:
 		}
 		goto tr82
 	st240:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof240
 		}
 	st_case_240:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -10254,12 +12032,12 @@ tr33:
 			goto st241
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10267,11 +12045,11 @@ tr33:
 		}
 		goto tr82
 	st241:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof241
 		}
 	st_case_241:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -10282,12 +12060,12 @@ tr33:
 			goto tr364
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10295,11 +12073,11 @@ tr33:
 		}
 		goto tr82
 	st242:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof242
 		}
 	st_case_242:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -10310,12 +12088,12 @@ tr33:
 			goto st243
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10323,11 +12101,11 @@ tr33:
 		}
 		goto tr82
 	st243:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof243
 		}
 	st_case_243:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -10338,12 +12116,12 @@ tr33:
 			goto st244
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10351,11 +12129,11 @@ tr33:
 		}
 		goto tr82
 	st244:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof244
 		}
 	st_case_244:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -10366,12 +12144,12 @@ tr33:
 			goto tr367
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10379,11 +12157,11 @@ tr33:
 		}
 		goto tr82
 	st245:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof245
 		}
 	st_case_245:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -10394,12 +12172,12 @@ tr33:
 			goto st246
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10407,11 +12185,11 @@ tr33:
 		}
 		goto tr82
 	st246:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof246
 		}
 	st_case_246:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -10422,12 +12200,12 @@ tr33:
 			goto st247
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10435,11 +12213,11 @@ tr33:
 		}
 		goto tr369
 	st247:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof247
 		}
 	st_case_247:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -10450,12 +12228,12 @@ tr33:
 			goto st248
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10463,11 +12241,11 @@ tr33:
 		}
 		goto tr82
 	st248:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof248
 		}
 	st_case_248:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -10478,12 +12256,12 @@ tr33:
 			goto st249
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10491,11 +12269,11 @@ tr33:
 		}
 		goto tr82
 	st249:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof249
 		}
 	st_case_249:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -10506,12 +12284,12 @@ tr33:
 			goto tr373
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10519,11 +12297,11 @@ tr33:
 		}
 		goto tr82
 	st250:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof250
 		}
 	st_case_250:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -10534,12 +12312,12 @@ tr33:
 			goto st251
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10547,11 +12325,11 @@ tr33:
 		}
 		goto tr82
 	st251:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof251
 		}
 	st_case_251:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -10562,12 +12340,12 @@ tr33:
 			goto tr375
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10575,11 +12353,11 @@ tr33:
 		}
 		goto tr82
 	st252:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof252
 		}
 	st_case_252:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -10590,12 +12368,12 @@ tr33:
 			goto st253
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10603,11 +12381,11 @@ tr33:
 		}
 		goto tr82
 	st253:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof253
 		}
 	st_case_253:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -10618,12 +12396,12 @@ tr33:
 			goto tr377
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10631,11 +12409,11 @@ tr33:
 		}
 		goto tr82
 	st254:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof254
 		}
 	st_case_254:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -10646,12 +12424,12 @@ tr33:
 			goto st255
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10659,11 +12437,11 @@ tr33:
 		}
 		goto tr82
 	st255:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof255
 		}
 	st_case_255:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -10678,12 +12456,12 @@ tr33:
 			goto st258
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10691,11 +12469,11 @@ tr33:
 		}
 		goto tr82
 	st256:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof256
 		}
 	st_case_256:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -10706,12 +12484,12 @@ tr33:
 			goto st257
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10719,11 +12497,11 @@ tr33:
 		}
 		goto tr82
 	st257:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof257
 		}
 	st_case_257:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -10734,12 +12512,12 @@ tr33:
 			goto tr382
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10747,11 +12525,11 @@ tr33:
 		}
 		goto tr82
 	st258:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof258
 		}
 	st_case_258:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -10762,12 +12540,12 @@ tr33:
 			goto st259
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10775,11 +12553,11 @@ tr33:
 		}
 		goto tr82
 	st259:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof259
 		}
 	st_case_259:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 80:
@@ -10790,12 +12568,12 @@ tr33:
 			goto tr384
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10803,11 +12581,11 @@ tr33:
 		}
 		goto tr82
 	st260:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof260
 		}
 	st_case_260:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -10826,12 +12604,12 @@ tr33:
 			goto st269
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10839,11 +12617,11 @@ tr33:
 		}
 		goto tr82
 	st261:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof261
 		}
 	st_case_261:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 86:
@@ -10854,12 +12632,12 @@ tr33:
 			goto st262
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10867,11 +12645,11 @@ tr33:
 		}
 		goto tr82
 	st262:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof262
 		}
 	st_case_262:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -10882,12 +12660,12 @@ tr33:
 			goto st263
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10895,11 +12673,11 @@ tr33:
 		}
 		goto tr82
 	st263:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof263
 		}
 	st_case_263:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -10910,12 +12688,12 @@ tr33:
 			goto st264
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10923,11 +12701,11 @@ tr33:
 		}
 		goto tr82
 	st264:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof264
 		}
 	st_case_264:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -10938,12 +12716,12 @@ tr33:
 			goto tr391
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10951,11 +12729,11 @@ tr33:
 		}
 		goto tr82
 	st265:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof265
 		}
 	st_case_265:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -10966,12 +12744,12 @@ tr33:
 			goto st266
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -10979,11 +12757,11 @@ tr33:
 		}
 		goto tr82
 	st266:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof266
 		}
 	st_case_266:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -10994,12 +12772,12 @@ tr33:
 			goto st267
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11007,11 +12785,11 @@ tr33:
 		}
 		goto tr82
 	st267:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof267
 		}
 	st_case_267:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11022,12 +12800,12 @@ tr33:
 			goto st268
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11035,11 +12813,11 @@ tr33:
 		}
 		goto tr82
 	st268:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof268
 		}
 	st_case_268:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -11050,12 +12828,12 @@ tr33:
 			goto tr395
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11063,11 +12841,11 @@ tr33:
 		}
 		goto tr82
 	st269:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof269
 		}
 	st_case_269:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -11078,12 +12856,12 @@ tr33:
 			goto st270
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11091,11 +12869,11 @@ tr33:
 		}
 		goto tr82
 	st270:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof270
 		}
 	st_case_270:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -11106,12 +12884,12 @@ tr33:
 			goto tr397
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11119,11 +12897,11 @@ tr33:
 		}
 		goto tr82
 	st271:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof271
 		}
 	st_case_271:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 70:
@@ -11146,12 +12924,12 @@ tr33:
 			goto st293
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11159,11 +12937,11 @@ tr33:
 		}
 		goto tr82
 	st272:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof272
 		}
 	st_case_272:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -11174,12 +12952,12 @@ tr33:
 			goto st273
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11187,11 +12965,11 @@ tr33:
 		}
 		goto tr82
 	st273:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof273
 		}
 	st_case_273:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 75:
@@ -11202,12 +12980,12 @@ tr33:
 			goto st274
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11215,11 +12993,11 @@ tr33:
 		}
 		goto tr82
 	st274:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof274
 		}
 	st_case_274:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11230,12 +13008,12 @@ tr33:
 			goto tr404
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11243,11 +13021,11 @@ tr33:
 		}
 		goto tr82
 	st275:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof275
 		}
 	st_case_275:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -11270,12 +13048,12 @@ tr33:
 			goto st283
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11283,11 +13061,11 @@ tr33:
 		}
 		goto tr405
 	st276:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof276
 		}
 	st_case_276:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11298,12 +13076,12 @@ tr33:
 			goto st277
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11311,11 +13089,11 @@ tr33:
 		}
 		goto tr82
 	st277:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof277
 		}
 	st_case_277:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 88:
@@ -11326,12 +13104,12 @@ tr33:
 			goto tr411
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11339,11 +13117,11 @@ tr33:
 		}
 		goto tr82
 	st278:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof278
 		}
 	st_case_278:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11354,12 +13132,12 @@ tr33:
 			goto st279
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11367,11 +13145,11 @@ tr33:
 		}
 		goto tr82
 	st279:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof279
 		}
 	st_case_279:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -11382,12 +13160,12 @@ tr33:
 			goto tr413
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11395,11 +13173,11 @@ tr33:
 		}
 		goto tr82
 	st280:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof280
 		}
 	st_case_280:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11410,12 +13188,12 @@ tr33:
 			goto st281
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11423,11 +13201,11 @@ tr33:
 		}
 		goto tr82
 	st281:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof281
 		}
 	st_case_281:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -11438,12 +13216,12 @@ tr33:
 			goto st282
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11451,11 +13229,11 @@ tr33:
 		}
 		goto tr82
 	st282:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof282
 		}
 	st_case_282:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -11466,12 +13244,12 @@ tr33:
 			goto tr416
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11479,11 +13257,11 @@ tr33:
 		}
 		goto tr82
 	st283:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof283
 		}
 	st_case_283:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11498,12 +13276,12 @@ tr33:
 			goto tr419
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11511,11 +13289,11 @@ tr33:
 		}
 		goto tr417
 	st284:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof284
 		}
 	st_case_284:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -11530,12 +13308,12 @@ tr33:
 			goto st287
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11543,11 +13321,11 @@ tr33:
 		}
 		goto tr82
 	st285:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof285
 		}
 	st_case_285:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11558,12 +13336,12 @@ tr33:
 			goto st286
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11571,11 +13349,11 @@ tr33:
 		}
 		goto tr82
 	st286:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof286
 		}
 	st_case_286:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -11586,12 +13364,12 @@ tr33:
 			goto tr423
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11599,11 +13377,11 @@ tr33:
 		}
 		goto tr82
 	st287:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof287
 		}
 	st_case_287:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -11618,12 +13396,12 @@ tr33:
 			goto st291
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11631,11 +13409,11 @@ tr33:
 		}
 		goto tr82
 	st288:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof288
 		}
 	st_case_288:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -11646,12 +13424,12 @@ tr33:
 			goto st289
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11659,11 +13437,11 @@ tr33:
 		}
 		goto tr82
 	st289:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof289
 		}
 	st_case_289:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -11674,12 +13452,12 @@ tr33:
 			goto st290
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11687,11 +13465,11 @@ tr33:
 		}
 		goto tr82
 	st290:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof290
 		}
 	st_case_290:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -11702,12 +13480,12 @@ tr33:
 			goto tr428
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11715,11 +13493,11 @@ tr33:
 		}
 		goto tr82
 	st291:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof291
 		}
 	st_case_291:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -11730,12 +13508,12 @@ tr33:
 			goto st292
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11743,11 +13521,11 @@ tr33:
 		}
 		goto tr82
 	st292:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof292
 		}
 	st_case_292:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -11758,12 +13536,12 @@ tr33:
 			goto tr430
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11771,11 +13549,11 @@ tr33:
 		}
 		goto tr82
 	st293:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof293
 		}
 	st_case_293:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -11790,12 +13568,12 @@ tr33:
 			goto st297
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11803,11 +13581,11 @@ tr33:
 		}
 		goto tr431
 	st294:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof294
 		}
 	st_case_294:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -11818,12 +13596,12 @@ tr33:
 			goto st295
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11831,11 +13609,11 @@ tr33:
 		}
 		goto tr82
 	st295:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof295
 		}
 	st_case_295:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -11846,12 +13624,12 @@ tr33:
 			goto st296
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11859,11 +13637,11 @@ tr33:
 		}
 		goto tr82
 	st296:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof296
 		}
 	st_case_296:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -11874,12 +13652,12 @@ tr33:
 			goto tr436
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11887,11 +13665,11 @@ tr33:
 		}
 		goto tr82
 	st297:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof297
 		}
 	st_case_297:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -11902,12 +13680,12 @@ tr33:
 			goto st298
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11915,11 +13693,11 @@ tr33:
 		}
 		goto tr82
 	st298:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof298
 		}
 	st_case_298:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -11930,12 +13708,12 @@ tr33:
 			goto st299
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11943,11 +13721,11 @@ tr33:
 		}
 		goto tr82
 	st299:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof299
 		}
 	st_case_299:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -11958,12 +13736,12 @@ tr33:
 			goto st300
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11971,11 +13749,11 @@ tr33:
 		}
 		goto tr82
 	st300:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof300
 		}
 	st_case_300:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -11986,12 +13764,12 @@ tr33:
 			goto st301
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -11999,11 +13777,11 @@ tr33:
 		}
 		goto tr82
 	st301:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof301
 		}
 	st_case_301:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -12014,12 +13792,12 @@ tr33:
 			goto st302
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12027,11 +13805,11 @@ tr33:
 		}
 		goto tr82
 	st302:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof302
 		}
 	st_case_302:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -12042,12 +13820,12 @@ tr33:
 			goto tr442
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12055,11 +13833,11 @@ tr33:
 		}
 		goto tr82
 	st303:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof303
 		}
 	st_case_303:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -12070,12 +13848,12 @@ tr33:
 			goto st304
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12083,11 +13861,11 @@ tr33:
 		}
 		goto tr82
 	st304:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof304
 		}
 	st_case_304:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -12098,12 +13876,12 @@ tr33:
 			goto st305
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12111,11 +13889,11 @@ tr33:
 		}
 		goto tr82
 	st305:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof305
 		}
 	st_case_305:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -12126,12 +13904,12 @@ tr33:
 			goto tr445
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12139,11 +13917,11 @@ tr33:
 		}
 		goto tr82
 	st306:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof306
 		}
 	st_case_306:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -12154,12 +13932,12 @@ tr33:
 			goto st307
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12167,11 +13945,11 @@ tr33:
 		}
 		goto tr82
 	st307:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof307
 		}
 	st_case_307:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -12182,12 +13960,12 @@ tr33:
 			goto tr447
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12195,11 +13973,11 @@ tr33:
 		}
 		goto tr82
 	st308:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof308
 		}
 	st_case_308:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -12222,12 +14000,12 @@ tr33:
 			goto st323
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12235,11 +14013,11 @@ tr33:
 		}
 		goto tr82
 	st309:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof309
 		}
 	st_case_309:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -12254,12 +14032,12 @@ tr33:
 			goto st311
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12267,11 +14045,11 @@ tr33:
 		}
 		goto tr82
 	st310:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof310
 		}
 	st_case_310:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -12282,12 +14060,12 @@ tr33:
 			goto tr454
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12295,11 +14073,11 @@ tr33:
 		}
 		goto tr82
 	st311:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof311
 		}
 	st_case_311:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -12310,12 +14088,12 @@ tr33:
 			goto st312
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12323,11 +14101,11 @@ tr33:
 		}
 		goto tr82
 	st312:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof312
 		}
 	st_case_312:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -12338,12 +14116,12 @@ tr33:
 			goto st313
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12351,11 +14129,11 @@ tr33:
 		}
 		goto tr82
 	st313:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof313
 		}
 	st_case_313:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -12366,12 +14144,12 @@ tr33:
 			goto st314
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12379,11 +14157,11 @@ tr33:
 		}
 		goto tr82
 	st314:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof314
 		}
 	st_case_314:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -12394,12 +14172,12 @@ tr33:
 			goto tr458
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12407,11 +14185,11 @@ tr33:
 		}
 		goto tr82
 	st315:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof315
 		}
 	st_case_315:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 70:
@@ -12426,12 +14204,12 @@ tr33:
 			goto st317
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12439,11 +14217,11 @@ tr33:
 		}
 		goto tr82
 	st316:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof316
 		}
 	st_case_316:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -12454,12 +14232,12 @@ tr33:
 			goto tr461
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12467,11 +14245,11 @@ tr33:
 		}
 		goto tr82
 	st317:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof317
 		}
 	st_case_317:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -12482,12 +14260,12 @@ tr33:
 			goto st318
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12495,11 +14273,11 @@ tr33:
 		}
 		goto tr82
 	st318:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof318
 		}
 	st_case_318:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -12510,12 +14288,12 @@ tr33:
 			goto tr463
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12523,11 +14301,11 @@ tr33:
 		}
 		goto tr82
 	st319:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof319
 		}
 	st_case_319:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 75:
@@ -12542,12 +14320,12 @@ tr33:
 			goto st321
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12555,11 +14333,11 @@ tr33:
 		}
 		goto tr82
 	st320:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof320
 		}
 	st_case_320:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -12570,12 +14348,12 @@ tr33:
 			goto tr466
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12583,11 +14361,11 @@ tr33:
 		}
 		goto tr82
 	st321:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof321
 		}
 	st_case_321:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -12598,12 +14376,12 @@ tr33:
 			goto st322
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12611,11 +14389,11 @@ tr33:
 		}
 		goto tr82
 	st322:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof322
 		}
 	st_case_322:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -12626,12 +14404,12 @@ tr33:
 			goto tr468
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12639,11 +14417,11 @@ tr33:
 		}
 		goto tr82
 	st323:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof323
 		}
 	st_case_323:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -12654,12 +14432,12 @@ tr33:
 			goto st324
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12667,11 +14445,11 @@ tr33:
 		}
 		goto tr82
 	st324:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof324
 		}
 	st_case_324:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -12686,12 +14464,12 @@ tr33:
 			goto st326
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12699,11 +14477,11 @@ tr33:
 		}
 		goto tr82
 	st325:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof325
 		}
 	st_case_325:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -12714,12 +14492,12 @@ tr33:
 			goto tr472
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12727,11 +14505,11 @@ tr33:
 		}
 		goto tr82
 	st326:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof326
 		}
 	st_case_326:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -12742,12 +14520,12 @@ tr33:
 			goto st327
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12755,11 +14533,11 @@ tr33:
 		}
 		goto tr82
 	st327:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof327
 		}
 	st_case_327:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -12770,12 +14548,12 @@ tr33:
 			goto tr474
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12783,11 +14561,11 @@ tr33:
 		}
 		goto tr82
 	st328:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof328
 		}
 	st_case_328:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -12802,12 +14580,12 @@ tr33:
 			goto st333
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12815,11 +14593,11 @@ tr33:
 		}
 		goto tr82
 	st329:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof329
 		}
 	st_case_329:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -12830,12 +14608,12 @@ tr33:
 			goto st330
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12843,11 +14621,11 @@ tr33:
 		}
 		goto tr82
 	st330:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof330
 		}
 	st_case_330:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -12858,12 +14636,12 @@ tr33:
 			goto st331
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12871,11 +14649,11 @@ tr33:
 		}
 		goto tr82
 	st331:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof331
 		}
 	st_case_331:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -12886,12 +14664,12 @@ tr33:
 			goto st332
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12899,11 +14677,11 @@ tr33:
 		}
 		goto tr82
 	st332:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof332
 		}
 	st_case_332:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -12914,12 +14692,12 @@ tr33:
 			goto tr480
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12927,11 +14705,11 @@ tr33:
 		}
 		goto tr82
 	st333:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof333
 		}
 	st_case_333:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -12942,12 +14720,12 @@ tr33:
 			goto st334
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12955,11 +14733,11 @@ tr33:
 		}
 		goto tr82
 	st334:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof334
 		}
 	st_case_334:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -12970,12 +14748,12 @@ tr33:
 			goto st335
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -12983,11 +14761,11 @@ tr33:
 		}
 		goto tr82
 	st335:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof335
 		}
 	st_case_335:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -12998,12 +14776,12 @@ tr33:
 			goto tr483
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13011,11 +14789,11 @@ tr33:
 		}
 		goto tr82
 	st336:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof336
 		}
 	st_case_336:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -13038,12 +14816,12 @@ tr33:
 			goto st360
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13051,11 +14829,11 @@ tr33:
 		}
 		goto tr82
 	st337:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof337
 		}
 	st_case_337:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -13066,12 +14844,12 @@ tr33:
 			goto st338
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13079,11 +14857,11 @@ tr33:
 		}
 		goto tr82
 	st338:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof338
 		}
 	st_case_338:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -13094,12 +14872,12 @@ tr33:
 			goto st339
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13107,11 +14885,11 @@ tr33:
 		}
 		goto tr82
 	st339:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof339
 		}
 	st_case_339:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -13122,12 +14900,12 @@ tr33:
 			goto st340
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13135,11 +14913,11 @@ tr33:
 		}
 		goto tr82
 	st340:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof340
 		}
 	st_case_340:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -13150,12 +14928,12 @@ tr33:
 			goto st341
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13163,11 +14941,11 @@ tr33:
 		}
 		goto tr82
 	st341:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof341
 		}
 	st_case_341:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -13178,12 +14956,12 @@ tr33:
 			goto st342
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13191,11 +14969,11 @@ tr33:
 		}
 		goto tr82
 	st342:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof342
 		}
 	st_case_342:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -13206,12 +14984,12 @@ tr33:
 			goto tr493
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13219,11 +14997,11 @@ tr33:
 		}
 		goto tr82
 	st343:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof343
 		}
 	st_case_343:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -13234,12 +15012,12 @@ tr33:
 			goto st344
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13247,11 +15025,11 @@ tr33:
 		}
 		goto tr82
 	st344:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof344
 		}
 	st_case_344:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -13262,12 +15040,12 @@ tr33:
 			goto st345
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13275,11 +15053,11 @@ tr33:
 		}
 		goto tr82
 	st345:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof345
 		}
 	st_case_345:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -13290,12 +15068,12 @@ tr33:
 			goto tr496
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13303,11 +15081,11 @@ tr33:
 		}
 		goto tr82
 	st346:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof346
 		}
 	st_case_346:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -13322,12 +15100,12 @@ tr33:
 			goto st353
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13335,11 +15113,11 @@ tr33:
 		}
 		goto tr82
 	st347:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof347
 		}
 	st_case_347:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -13350,12 +15128,12 @@ tr33:
 			goto st348
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13363,11 +15141,11 @@ tr33:
 		}
 		goto tr82
 	st348:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof348
 		}
 	st_case_348:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -13378,12 +15156,12 @@ tr33:
 			goto st349
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13391,11 +15169,11 @@ tr33:
 		}
 		goto tr82
 	st349:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof349
 		}
 	st_case_349:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -13406,12 +15184,12 @@ tr33:
 			goto st350
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13419,11 +15197,11 @@ tr33:
 		}
 		goto tr82
 	st350:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof350
 		}
 	st_case_350:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -13434,12 +15212,12 @@ tr33:
 			goto st351
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13447,11 +15225,11 @@ tr33:
 		}
 		goto tr82
 	st351:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof351
 		}
 	st_case_351:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 90:
@@ -13462,12 +15240,12 @@ tr33:
 			goto st352
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 89:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 121 {
+		case lex.data[(lex.p)] > 89:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 121 {
 				goto tr57
 			}
 		default:
@@ -13475,11 +15253,11 @@ tr33:
 		}
 		goto tr82
 	st352:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof352
 		}
 	st_case_352:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -13490,12 +15268,12 @@ tr33:
 			goto tr504
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13503,11 +15281,11 @@ tr33:
 		}
 		goto tr82
 	st353:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof353
 		}
 	st_case_353:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -13522,12 +15300,12 @@ tr33:
 			goto st357
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13535,11 +15313,11 @@ tr33:
 		}
 		goto tr505
 	st354:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof354
 		}
 	st_case_354:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -13550,12 +15328,12 @@ tr33:
 			goto st355
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13563,11 +15341,11 @@ tr33:
 		}
 		goto tr82
 	st355:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof355
 		}
 	st_case_355:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -13578,12 +15356,12 @@ tr33:
 			goto st356
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13591,11 +15369,11 @@ tr33:
 		}
 		goto tr82
 	st356:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof356
 		}
 	st_case_356:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -13606,12 +15384,12 @@ tr33:
 			goto tr510
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13619,11 +15397,11 @@ tr33:
 		}
 		goto tr82
 	st357:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof357
 		}
 	st_case_357:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -13634,12 +15412,12 @@ tr33:
 			goto st358
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13647,11 +15425,11 @@ tr33:
 		}
 		goto tr82
 	st358:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof358
 		}
 	st_case_358:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -13662,12 +15440,12 @@ tr33:
 			goto st359
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13675,11 +15453,11 @@ tr33:
 		}
 		goto tr82
 	st359:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof359
 		}
 	st_case_359:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -13690,12 +15468,12 @@ tr33:
 			goto tr513
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13703,11 +15481,11 @@ tr33:
 		}
 		goto tr82
 	st360:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof360
 		}
 	st_case_360:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -13722,12 +15500,12 @@ tr33:
 			goto st363
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13735,11 +15513,11 @@ tr33:
 		}
 		goto tr82
 	st361:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof361
 		}
 	st_case_361:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -13750,12 +15528,12 @@ tr33:
 			goto st362
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13763,11 +15541,11 @@ tr33:
 		}
 		goto tr82
 	st362:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof362
 		}
 	st_case_362:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -13778,12 +15556,12 @@ tr33:
 			goto tr518
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13791,11 +15569,11 @@ tr33:
 		}
 		goto tr517
 	st363:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof363
 		}
 	st_case_363:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -13806,12 +15584,12 @@ tr33:
 			goto st364
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13819,11 +15597,11 @@ tr33:
 		}
 		goto tr82
 	st364:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof364
 		}
 	st_case_364:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -13834,12 +15612,12 @@ tr33:
 			goto st365
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13847,11 +15625,11 @@ tr33:
 		}
 		goto tr82
 	st365:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof365
 		}
 	st_case_365:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -13862,12 +15640,12 @@ tr33:
 			goto st366
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13875,11 +15653,11 @@ tr33:
 		}
 		goto tr82
 	st366:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof366
 		}
 	st_case_366:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -13890,12 +15668,12 @@ tr33:
 			goto tr522
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13903,11 +15681,11 @@ tr33:
 		}
 		goto tr82
 	st367:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof367
 		}
 	st_case_367:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 70:
@@ -13930,12 +15708,12 @@ tr33:
 			goto st383
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13943,11 +15721,11 @@ tr33:
 		}
 		goto tr82
 	st368:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof368
 		}
 	st_case_368:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 70:
@@ -13958,12 +15736,12 @@ tr33:
 			goto st369
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13971,11 +15749,11 @@ tr33:
 		}
 		goto tr527
 	st369:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof369
 		}
 	st_case_369:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -13986,12 +15764,12 @@ tr33:
 			goto st370
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -13999,11 +15777,11 @@ tr33:
 		}
 		goto tr82
 	st370:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof370
 		}
 	st_case_370:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -14014,12 +15792,12 @@ tr33:
 			goto st371
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14027,11 +15805,11 @@ tr33:
 		}
 		goto tr82
 	st371:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof371
 		}
 	st_case_371:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -14042,12 +15820,12 @@ tr33:
 			goto tr531
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14055,11 +15833,11 @@ tr33:
 		}
 		goto tr82
 	st372:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof372
 		}
 	st_case_372:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -14070,12 +15848,12 @@ tr33:
 			goto st373
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14083,11 +15861,11 @@ tr33:
 		}
 		goto tr532
 	st373:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof373
 		}
 	st_case_373:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -14098,12 +15876,12 @@ tr33:
 			goto tr534
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14111,11 +15889,11 @@ tr33:
 		}
 		goto tr82
 	st374:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof374
 		}
 	st_case_374:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -14126,12 +15904,12 @@ tr33:
 			goto st375
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14139,11 +15917,11 @@ tr33:
 		}
 		goto tr535
 	st375:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof375
 		}
 	st_case_375:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -14158,12 +15936,12 @@ tr33:
 			goto st377
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14171,11 +15949,11 @@ tr33:
 		}
 		goto tr82
 	st376:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof376
 		}
 	st_case_376:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -14186,12 +15964,12 @@ tr33:
 			goto tr539
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14199,11 +15977,11 @@ tr33:
 		}
 		goto tr82
 	st377:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof377
 		}
 	st_case_377:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -14214,12 +15992,12 @@ tr33:
 			goto st378
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14227,11 +16005,11 @@ tr33:
 		}
 		goto tr82
 	st378:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof378
 		}
 	st_case_378:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -14242,12 +16020,12 @@ tr33:
 			goto st379
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14255,11 +16033,11 @@ tr33:
 		}
 		goto tr82
 	st379:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof379
 		}
 	st_case_379:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -14270,12 +16048,12 @@ tr33:
 			goto st380
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14283,11 +16061,11 @@ tr33:
 		}
 		goto tr82
 	st380:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof380
 		}
 	st_case_380:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -14298,12 +16076,12 @@ tr33:
 			goto st381
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14311,11 +16089,11 @@ tr33:
 		}
 		goto tr82
 	st381:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof381
 		}
 	st_case_381:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -14326,12 +16104,12 @@ tr33:
 			goto st382
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14339,11 +16117,11 @@ tr33:
 		}
 		goto tr82
 	st382:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof382
 		}
 	st_case_382:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -14354,12 +16132,12 @@ tr33:
 			goto tr545
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14367,11 +16145,11 @@ tr33:
 		}
 		goto tr82
 	st383:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof383
 		}
 	st_case_383:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -14382,12 +16160,12 @@ tr33:
 			goto st384
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14395,11 +16173,11 @@ tr33:
 		}
 		goto tr82
 	st384:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof384
 		}
 	st_case_384:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -14410,12 +16188,12 @@ tr33:
 			goto st385
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14423,11 +16201,11 @@ tr33:
 		}
 		goto tr82
 	st385:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof385
 		}
 	st_case_385:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -14438,12 +16216,12 @@ tr33:
 			goto tr548
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14451,11 +16229,11 @@ tr33:
 		}
 		goto tr82
 	st386:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof386
 		}
 	st_case_386:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -14474,12 +16252,12 @@ tr33:
 			goto st397
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14487,11 +16265,11 @@ tr33:
 		}
 		goto tr82
 	st387:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof387
 		}
 	st_case_387:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -14502,12 +16280,12 @@ tr33:
 			goto st388
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14515,11 +16293,11 @@ tr33:
 		}
 		goto tr82
 	st388:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof388
 		}
 	st_case_388:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -14530,12 +16308,12 @@ tr33:
 			goto st389
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14543,11 +16321,11 @@ tr33:
 		}
 		goto tr82
 	st389:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof389
 		}
 	st_case_389:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -14558,12 +16336,12 @@ tr33:
 			goto st390
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14571,11 +16349,11 @@ tr33:
 		}
 		goto tr82
 	st390:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof390
 		}
 	st_case_390:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -14586,12 +16364,12 @@ tr33:
 			goto st391
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14599,11 +16377,11 @@ tr33:
 		}
 		goto tr82
 	st391:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof391
 		}
 	st_case_391:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -14614,12 +16392,12 @@ tr33:
 			goto st392
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14627,11 +16405,11 @@ tr33:
 		}
 		goto tr82
 	st392:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof392
 		}
 	st_case_392:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -14642,12 +16420,12 @@ tr33:
 			goto st393
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14655,11 +16433,11 @@ tr33:
 		}
 		goto tr82
 	st393:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof393
 		}
 	st_case_393:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -14670,12 +16448,12 @@ tr33:
 			goto tr558
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14683,11 +16461,11 @@ tr33:
 		}
 		goto tr82
 	st394:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof394
 		}
 	st_case_394:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -14698,12 +16476,12 @@ tr33:
 			goto st395
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14711,11 +16489,11 @@ tr33:
 		}
 		goto tr82
 	st395:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof395
 		}
 	st_case_395:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -14726,12 +16504,12 @@ tr33:
 			goto st396
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14739,11 +16517,11 @@ tr33:
 		}
 		goto tr82
 	st396:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof396
 		}
 	st_case_396:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -14754,12 +16532,12 @@ tr33:
 			goto tr561
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14767,11 +16545,11 @@ tr33:
 		}
 		goto tr82
 	st397:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof397
 		}
 	st_case_397:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -14790,12 +16568,12 @@ tr33:
 			goto st406
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14803,11 +16581,11 @@ tr33:
 		}
 		goto tr82
 	st398:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof398
 		}
 	st_case_398:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 80:
@@ -14818,12 +16596,12 @@ tr33:
 			goto st399
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14831,11 +16609,11 @@ tr33:
 		}
 		goto tr82
 	st399:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof399
 		}
 	st_case_399:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -14846,12 +16624,12 @@ tr33:
 			goto st400
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14859,11 +16637,11 @@ tr33:
 		}
 		goto tr82
 	st400:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof400
 		}
 	st_case_400:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -14874,12 +16652,12 @@ tr33:
 			goto st401
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14887,11 +16665,11 @@ tr33:
 		}
 		goto tr82
 	st401:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof401
 		}
 	st_case_401:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -14902,12 +16680,12 @@ tr33:
 			goto tr568
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14915,11 +16693,11 @@ tr33:
 		}
 		goto tr82
 	st402:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof402
 		}
 	st_case_402:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -14930,12 +16708,12 @@ tr33:
 			goto st403
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14943,11 +16721,11 @@ tr33:
 		}
 		goto tr82
 	st403:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof403
 		}
 	st_case_403:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -14958,12 +16736,12 @@ tr33:
 			goto st404
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14971,11 +16749,11 @@ tr33:
 		}
 		goto tr82
 	st404:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof404
 		}
 	st_case_404:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -14986,12 +16764,12 @@ tr33:
 			goto st405
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -14999,11 +16777,11 @@ tr33:
 		}
 		goto tr82
 	st405:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof405
 		}
 	st_case_405:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 89:
@@ -15014,12 +16792,12 @@ tr33:
 			goto tr572
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15027,11 +16805,11 @@ tr33:
 		}
 		goto tr82
 	st406:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof406
 		}
 	st_case_406:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -15042,12 +16820,12 @@ tr33:
 			goto st407
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15055,11 +16833,11 @@ tr33:
 		}
 		goto tr82
 	st407:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof407
 		}
 	st_case_407:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -15070,12 +16848,12 @@ tr33:
 			goto st408
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15083,11 +16861,11 @@ tr33:
 		}
 		goto tr82
 	st408:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof408
 		}
 	st_case_408:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -15098,12 +16876,12 @@ tr33:
 			goto st409
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15111,11 +16889,11 @@ tr33:
 		}
 		goto tr82
 	st409:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof409
 		}
 	st_case_409:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -15126,12 +16904,12 @@ tr33:
 			goto tr576
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15139,11 +16917,11 @@ tr33:
 		}
 		goto tr82
 	st410:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof410
 		}
 	st_case_410:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -15154,12 +16932,12 @@ tr33:
 			goto st411
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15167,11 +16945,11 @@ tr33:
 		}
 		goto tr82
 	st411:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof411
 		}
 	st_case_411:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -15182,12 +16960,12 @@ tr33:
 			goto st412
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15195,11 +16973,11 @@ tr33:
 		}
 		goto tr82
 	st412:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof412
 		}
 	st_case_412:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -15210,12 +16988,12 @@ tr33:
 			goto st413
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15223,11 +17001,11 @@ tr33:
 		}
 		goto tr82
 	st413:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof413
 		}
 	st_case_413:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15238,12 +17016,12 @@ tr33:
 			goto tr580
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15251,11 +17029,11 @@ tr33:
 		}
 		goto tr82
 	st414:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof414
 		}
 	st_case_414:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15274,12 +17052,12 @@ tr33:
 			goto st455
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15287,11 +17065,11 @@ tr33:
 		}
 		goto tr82
 	st415:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof415
 		}
 	st_case_415:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -15326,12 +17104,12 @@ tr33:
 			goto st449
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15339,11 +17117,11 @@ tr33:
 		}
 		goto tr82
 	st416:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof416
 		}
 	st_case_416:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -15358,12 +17136,12 @@ tr33:
 			goto tr592
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15371,11 +17149,11 @@ tr33:
 		}
 		goto tr82
 	st417:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof417
 		}
 	st_case_417:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -15386,12 +17164,12 @@ tr33:
 			goto st418
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15399,11 +17177,11 @@ tr33:
 		}
 		goto tr82
 	st418:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof418
 		}
 	st_case_418:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -15414,12 +17192,12 @@ tr33:
 			goto st419
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15427,11 +17205,11 @@ tr33:
 		}
 		goto tr82
 	st419:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof419
 		}
 	st_case_419:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -15442,12 +17220,12 @@ tr33:
 			goto st420
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15455,11 +17233,11 @@ tr33:
 		}
 		goto tr82
 	st420:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof420
 		}
 	st_case_420:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -15470,12 +17248,12 @@ tr33:
 			goto st421
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15483,11 +17261,11 @@ tr33:
 		}
 		goto tr82
 	st421:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof421
 		}
 	st_case_421:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 86:
@@ -15498,12 +17276,12 @@ tr33:
 			goto st422
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15511,11 +17289,11 @@ tr33:
 		}
 		goto tr82
 	st422:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof422
 		}
 	st_case_422:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15526,12 +17304,12 @@ tr33:
 			goto tr598
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15539,11 +17317,11 @@ tr33:
 		}
 		goto tr82
 	st423:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof423
 		}
 	st_case_423:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15554,12 +17332,12 @@ tr33:
 			goto st424
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15567,11 +17345,11 @@ tr33:
 		}
 		goto tr82
 	st424:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof424
 		}
 	st_case_424:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -15582,12 +17360,12 @@ tr33:
 			goto st425
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15595,11 +17373,11 @@ tr33:
 		}
 		goto tr82
 	st425:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof425
 		}
 	st_case_425:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15610,12 +17388,12 @@ tr33:
 			goto st426
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15623,11 +17401,11 @@ tr33:
 		}
 		goto tr82
 	st426:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof426
 		}
 	st_case_426:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -15638,12 +17416,12 @@ tr33:
 			goto st427
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15651,11 +17429,11 @@ tr33:
 		}
 		goto tr82
 	st427:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof427
 		}
 	st_case_427:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -15666,12 +17444,12 @@ tr33:
 			goto st428
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15679,11 +17457,11 @@ tr33:
 		}
 		goto tr82
 	st428:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof428
 		}
 	st_case_428:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15694,12 +17472,12 @@ tr33:
 			goto st429
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15707,11 +17485,11 @@ tr33:
 		}
 		goto tr82
 	st429:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof429
 		}
 	st_case_429:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -15722,12 +17500,12 @@ tr33:
 			goto tr605
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15735,11 +17513,11 @@ tr33:
 		}
 		goto tr82
 	st430:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof430
 		}
 	st_case_430:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15750,12 +17528,12 @@ tr33:
 			goto st431
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15763,11 +17541,11 @@ tr33:
 		}
 		goto tr82
 	st431:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof431
 		}
 	st_case_431:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -15778,12 +17556,12 @@ tr33:
 			goto st432
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15791,11 +17569,11 @@ tr33:
 		}
 		goto tr82
 	st432:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof432
 		}
 	st_case_432:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -15806,12 +17584,12 @@ tr33:
 			goto st433
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15819,11 +17597,11 @@ tr33:
 		}
 		goto tr82
 	st433:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof433
 		}
 	st_case_433:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -15834,12 +17612,12 @@ tr33:
 			goto st434
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15847,11 +17625,11 @@ tr33:
 		}
 		goto tr82
 	st434:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof434
 		}
 	st_case_434:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -15862,12 +17640,12 @@ tr33:
 			goto st435
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15875,11 +17653,11 @@ tr33:
 		}
 		goto tr82
 	st435:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof435
 		}
 	st_case_435:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -15890,12 +17668,12 @@ tr33:
 			goto st436
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15903,11 +17681,11 @@ tr33:
 		}
 		goto tr82
 	st436:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof436
 		}
 	st_case_436:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15918,12 +17696,12 @@ tr33:
 			goto tr612
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15931,11 +17709,11 @@ tr33:
 		}
 		goto tr82
 	st437:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof437
 		}
 	st_case_437:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -15950,12 +17728,12 @@ tr33:
 			goto st439
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15963,11 +17741,11 @@ tr33:
 		}
 		goto tr82
 	st438:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof438
 		}
 	st_case_438:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -15978,12 +17756,12 @@ tr33:
 			goto tr615
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -15991,11 +17769,11 @@ tr33:
 		}
 		goto tr82
 	st439:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof439
 		}
 	st_case_439:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -16006,12 +17784,12 @@ tr33:
 			goto st440
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16019,11 +17797,11 @@ tr33:
 		}
 		goto tr82
 	st440:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof440
 		}
 	st_case_440:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -16034,12 +17812,12 @@ tr33:
 			goto st441
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16047,11 +17825,11 @@ tr33:
 		}
 		goto tr82
 	st441:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof441
 		}
 	st_case_441:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -16062,12 +17840,12 @@ tr33:
 			goto st442
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16075,11 +17853,11 @@ tr33:
 		}
 		goto tr82
 	st442:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof442
 		}
 	st_case_442:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -16090,12 +17868,12 @@ tr33:
 			goto tr619
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16103,11 +17881,11 @@ tr33:
 		}
 		goto tr82
 	st443:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof443
 		}
 	st_case_443:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -16118,12 +17896,12 @@ tr33:
 			goto st444
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16131,11 +17909,11 @@ tr33:
 		}
 		goto tr82
 	st444:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof444
 		}
 	st_case_444:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -16146,12 +17924,12 @@ tr33:
 			goto st445
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16159,11 +17937,11 @@ tr33:
 		}
 		goto tr82
 	st445:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof445
 		}
 	st_case_445:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -16174,12 +17952,12 @@ tr33:
 			goto st446
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16187,11 +17965,11 @@ tr33:
 		}
 		goto tr82
 	st446:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof446
 		}
 	st_case_446:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -16202,12 +17980,12 @@ tr33:
 			goto st447
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16215,11 +17993,11 @@ tr33:
 		}
 		goto tr82
 	st447:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof447
 		}
 	st_case_447:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -16230,12 +18008,12 @@ tr33:
 			goto st448
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16243,11 +18021,11 @@ tr33:
 		}
 		goto tr82
 	st448:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof448
 		}
 	st_case_448:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -16258,12 +18036,12 @@ tr33:
 			goto tr625
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16271,11 +18049,11 @@ tr33:
 		}
 		goto tr82
 	st449:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof449
 		}
 	st_case_449:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -16286,12 +18064,12 @@ tr33:
 			goto st450
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16299,11 +18077,11 @@ tr33:
 		}
 		goto tr82
 	st450:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof450
 		}
 	st_case_450:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 75:
@@ -16314,12 +18092,12 @@ tr33:
 			goto st451
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16327,11 +18105,11 @@ tr33:
 		}
 		goto tr82
 	st451:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof451
 		}
 	st_case_451:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -16342,12 +18120,12 @@ tr33:
 			goto tr628
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16355,11 +18133,11 @@ tr33:
 		}
 		goto tr82
 	st452:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof452
 		}
 	st_case_452:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -16370,12 +18148,12 @@ tr33:
 			goto st453
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16383,11 +18161,11 @@ tr33:
 		}
 		goto tr82
 	st453:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof453
 		}
 	st_case_453:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -16398,12 +18176,12 @@ tr33:
 			goto st454
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16411,11 +18189,11 @@ tr33:
 		}
 		goto tr82
 	st454:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof454
 		}
 	st_case_454:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -16426,12 +18204,12 @@ tr33:
 			goto tr631
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16439,11 +18217,11 @@ tr33:
 		}
 		goto tr82
 	st455:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof455
 		}
 	st_case_455:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -16458,12 +18236,12 @@ tr33:
 			goto tr633
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16471,11 +18249,11 @@ tr33:
 		}
 		goto tr82
 	st456:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof456
 		}
 	st_case_456:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -16490,12 +18268,12 @@ tr33:
 			goto st457
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16503,11 +18281,11 @@ tr33:
 		}
 		goto tr82
 	st457:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof457
 		}
 	st_case_457:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -16518,12 +18296,12 @@ tr33:
 			goto st458
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16531,11 +18309,11 @@ tr33:
 		}
 		goto tr82
 	st458:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof458
 		}
 	st_case_458:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -16546,12 +18324,12 @@ tr33:
 			goto st459
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16559,11 +18337,11 @@ tr33:
 		}
 		goto tr82
 	st459:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof459
 		}
 	st_case_459:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -16574,12 +18352,12 @@ tr33:
 			goto st460
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16587,11 +18365,11 @@ tr33:
 		}
 		goto tr82
 	st460:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof460
 		}
 	st_case_460:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 75:
@@ -16602,12 +18380,12 @@ tr33:
 			goto tr639
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16615,11 +18393,11 @@ tr33:
 		}
 		goto tr82
 	st461:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof461
 		}
 	st_case_461:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -16650,12 +18428,12 @@ tr33:
 			goto st509
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16663,11 +18441,11 @@ tr33:
 		}
 		goto tr82
 	st462:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof462
 		}
 	st_case_462:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -16678,12 +18456,12 @@ tr33:
 			goto st463
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16691,11 +18469,11 @@ tr33:
 		}
 		goto tr82
 	st463:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof463
 		}
 	st_case_463:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -16706,12 +18484,12 @@ tr33:
 			goto st464
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16719,11 +18497,11 @@ tr33:
 		}
 		goto tr82
 	st464:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof464
 		}
 	st_case_464:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -16734,12 +18512,12 @@ tr33:
 			goto st465
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16747,11 +18525,11 @@ tr33:
 		}
 		goto tr82
 	st465:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof465
 		}
 	st_case_465:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -16762,12 +18540,12 @@ tr33:
 			goto tr649
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16775,11 +18553,11 @@ tr33:
 		}
 		goto tr82
 	st466:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof466
 		}
 	st_case_466:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -16814,12 +18592,12 @@ tr33:
 			goto st495
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16827,11 +18605,11 @@ tr33:
 		}
 		goto tr82
 	st467:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof467
 		}
 	st_case_467:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -16842,12 +18620,12 @@ tr33:
 			goto st468
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16855,11 +18633,11 @@ tr33:
 		}
 		goto tr82
 	st468:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof468
 		}
 	st_case_468:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -16870,12 +18648,12 @@ tr33:
 			goto st469
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16883,11 +18661,11 @@ tr33:
 		}
 		goto tr82
 	st469:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof469
 		}
 	st_case_469:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -16898,12 +18676,12 @@ tr33:
 			goto tr659
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16911,11 +18689,11 @@ tr33:
 		}
 		goto tr82
 	st470:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof470
 		}
 	st_case_470:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -16926,12 +18704,12 @@ tr33:
 			goto st471
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16939,11 +18717,11 @@ tr33:
 		}
 		goto tr82
 	st471:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof471
 		}
 	st_case_471:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -16954,12 +18732,12 @@ tr33:
 			goto st472
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16967,11 +18745,11 @@ tr33:
 		}
 		goto tr82
 	st472:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof472
 		}
 	st_case_472:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -16982,12 +18760,12 @@ tr33:
 			goto tr662
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -16995,11 +18773,11 @@ tr33:
 		}
 		goto tr82
 	st473:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof473
 		}
 	st_case_473:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -17010,12 +18788,12 @@ tr33:
 			goto st474
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17023,11 +18801,11 @@ tr33:
 		}
 		goto tr82
 	st474:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof474
 		}
 	st_case_474:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -17038,12 +18816,12 @@ tr33:
 			goto st475
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17051,11 +18829,11 @@ tr33:
 		}
 		goto tr82
 	st475:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof475
 		}
 	st_case_475:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -17066,12 +18844,12 @@ tr33:
 			goto tr665
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17079,11 +18857,11 @@ tr33:
 		}
 		goto tr82
 	st476:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof476
 		}
 	st_case_476:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -17094,12 +18872,12 @@ tr33:
 			goto st477
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17107,11 +18885,11 @@ tr33:
 		}
 		goto tr82
 	st477:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof477
 		}
 	st_case_477:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -17122,12 +18900,12 @@ tr33:
 			goto st478
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17135,11 +18913,11 @@ tr33:
 		}
 		goto tr82
 	st478:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof478
 		}
 	st_case_478:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -17150,12 +18928,12 @@ tr33:
 			goto st479
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17163,11 +18941,11 @@ tr33:
 		}
 		goto tr82
 	st479:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof479
 		}
 	st_case_479:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -17178,12 +18956,12 @@ tr33:
 			goto st480
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17191,11 +18969,11 @@ tr33:
 		}
 		goto tr82
 	st480:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof480
 		}
 	st_case_480:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -17206,12 +18984,12 @@ tr33:
 			goto st481
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17219,11 +18997,11 @@ tr33:
 		}
 		goto tr82
 	st481:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof481
 		}
 	st_case_481:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -17234,12 +19012,12 @@ tr33:
 			goto tr671
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17247,11 +19025,11 @@ tr33:
 		}
 		goto tr82
 	st482:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof482
 		}
 	st_case_482:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -17262,12 +19040,12 @@ tr33:
 			goto st483
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17275,11 +19053,11 @@ tr33:
 		}
 		goto tr82
 	st483:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof483
 		}
 	st_case_483:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -17290,12 +19068,12 @@ tr33:
 			goto st484
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17303,11 +19081,11 @@ tr33:
 		}
 		goto tr82
 	st484:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof484
 		}
 	st_case_484:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -17318,12 +19096,12 @@ tr33:
 			goto st485
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17331,11 +19109,11 @@ tr33:
 		}
 		goto tr82
 	st485:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof485
 		}
 	st_case_485:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -17346,12 +19124,12 @@ tr33:
 			goto st486
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17359,11 +19137,11 @@ tr33:
 		}
 		goto tr82
 	st486:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof486
 		}
 	st_case_486:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 90:
@@ -17374,12 +19152,12 @@ tr33:
 			goto st487
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 89:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 121 {
+		case lex.data[(lex.p)] > 89:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 121 {
 				goto tr57
 			}
 		default:
@@ -17387,11 +19165,11 @@ tr33:
 		}
 		goto tr82
 	st487:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof487
 		}
 	st_case_487:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -17402,12 +19180,12 @@ tr33:
 			goto st488
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17415,11 +19193,11 @@ tr33:
 		}
 		goto tr82
 	st488:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof488
 		}
 	st_case_488:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -17430,12 +19208,12 @@ tr33:
 			goto st489
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17443,11 +19221,11 @@ tr33:
 		}
 		goto tr82
 	st489:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof489
 		}
 	st_case_489:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -17458,12 +19236,12 @@ tr33:
 			goto st490
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17471,11 +19249,11 @@ tr33:
 		}
 		goto tr82
 	st490:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof490
 		}
 	st_case_490:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -17486,12 +19264,12 @@ tr33:
 			goto tr680
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17499,11 +19277,11 @@ tr33:
 		}
 		goto tr82
 	st491:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof491
 		}
 	st_case_491:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -17514,12 +19292,12 @@ tr33:
 			goto st492
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17527,11 +19305,11 @@ tr33:
 		}
 		goto tr82
 	st492:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof492
 		}
 	st_case_492:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -17542,12 +19320,12 @@ tr33:
 			goto st493
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17555,11 +19333,11 @@ tr33:
 		}
 		goto tr82
 	st493:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof493
 		}
 	st_case_493:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -17570,12 +19348,12 @@ tr33:
 			goto st494
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17583,11 +19361,11 @@ tr33:
 		}
 		goto tr82
 	st494:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof494
 		}
 	st_case_494:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -17598,12 +19376,12 @@ tr33:
 			goto tr684
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17611,11 +19389,11 @@ tr33:
 		}
 		goto tr82
 	st495:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof495
 		}
 	st_case_495:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -17626,12 +19404,12 @@ tr33:
 			goto st496
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17639,11 +19417,11 @@ tr33:
 		}
 		goto tr685
 	st496:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof496
 		}
 	st_case_496:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 70:
@@ -17654,12 +19432,12 @@ tr33:
 			goto tr687
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17667,11 +19445,11 @@ tr33:
 		}
 		goto tr82
 	st497:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof497
 		}
 	st_case_497:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -17686,12 +19464,12 @@ tr33:
 			goto st500
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17699,11 +19477,11 @@ tr33:
 		}
 		goto tr82
 	st498:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof498
 		}
 	st_case_498:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -17714,12 +19492,12 @@ tr33:
 			goto st499
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17727,11 +19505,11 @@ tr33:
 		}
 		goto tr82
 	st499:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof499
 		}
 	st_case_499:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -17742,12 +19520,12 @@ tr33:
 			goto tr691
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17755,11 +19533,11 @@ tr33:
 		}
 		goto tr82
 	st500:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof500
 		}
 	st_case_500:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 87:
@@ -17770,12 +19548,12 @@ tr33:
 			goto tr692
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17783,11 +19561,11 @@ tr33:
 		}
 		goto tr82
 	st501:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof501
 		}
 	st_case_501:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -17798,12 +19576,12 @@ tr33:
 			goto st502
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17811,11 +19589,11 @@ tr33:
 		}
 		goto tr82
 	st502:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof502
 		}
 	st_case_502:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 80:
@@ -17826,12 +19604,12 @@ tr33:
 			goto tr694
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17839,11 +19617,11 @@ tr33:
 		}
 		goto tr82
 	st503:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof503
 		}
 	st_case_503:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -17854,12 +19632,12 @@ tr33:
 			goto st504
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17867,11 +19645,11 @@ tr33:
 		}
 		goto tr82
 	st504:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof504
 		}
 	st_case_504:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -17882,12 +19660,12 @@ tr33:
 			goto st505
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17895,11 +19673,11 @@ tr33:
 		}
 		goto tr82
 	st505:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof505
 		}
 	st_case_505:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -17910,12 +19688,12 @@ tr33:
 			goto st506
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17923,11 +19701,11 @@ tr33:
 		}
 		goto tr82
 	st506:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof506
 		}
 	st_case_506:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -17938,12 +19716,12 @@ tr33:
 			goto st507
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17951,11 +19729,11 @@ tr33:
 		}
 		goto tr82
 	st507:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof507
 		}
 	st_case_507:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -17966,12 +19744,12 @@ tr33:
 			goto st508
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -17979,11 +19757,11 @@ tr33:
 		}
 		goto tr82
 	st508:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof508
 		}
 	st_case_508:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -17994,12 +19772,12 @@ tr33:
 			goto tr700
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18007,11 +19785,11 @@ tr33:
 		}
 		goto tr82
 	st509:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof509
 		}
 	st_case_509:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -18026,12 +19804,12 @@ tr33:
 			goto st518
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18039,11 +19817,11 @@ tr33:
 		}
 		goto tr82
 	st510:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof510
 		}
 	st_case_510:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -18058,12 +19836,12 @@ tr33:
 			goto st512
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18071,11 +19849,11 @@ tr33:
 		}
 		goto tr82
 	st511:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof511
 		}
 	st_case_511:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -18086,12 +19864,12 @@ tr33:
 			goto tr705
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18099,11 +19877,11 @@ tr33:
 		}
 		goto tr82
 	st512:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof512
 		}
 	st_case_512:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -18114,12 +19892,12 @@ tr33:
 			goto st513
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18127,11 +19905,11 @@ tr33:
 		}
 		goto tr82
 	st513:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof513
 		}
 	st_case_513:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -18142,12 +19920,12 @@ tr33:
 			goto st514
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18155,11 +19933,11 @@ tr33:
 		}
 		goto tr82
 	st514:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof514
 		}
 	st_case_514:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -18170,12 +19948,12 @@ tr33:
 			goto st515
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18183,11 +19961,11 @@ tr33:
 		}
 		goto tr82
 	st515:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof515
 		}
 	st_case_515:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -18198,12 +19976,12 @@ tr33:
 			goto st516
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18211,11 +19989,11 @@ tr33:
 		}
 		goto tr82
 	st516:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof516
 		}
 	st_case_516:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -18226,12 +20004,12 @@ tr33:
 			goto st517
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18239,11 +20017,11 @@ tr33:
 		}
 		goto tr82
 	st517:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof517
 		}
 	st_case_517:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -18254,12 +20032,12 @@ tr33:
 			goto tr711
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18267,11 +20045,11 @@ tr33:
 		}
 		goto tr82
 	st518:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof518
 		}
 	st_case_518:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -18286,12 +20064,12 @@ tr33:
 			goto st520
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18299,11 +20077,11 @@ tr33:
 		}
 		goto tr82
 	st519:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof519
 		}
 	st_case_519:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -18314,12 +20092,12 @@ tr33:
 			goto tr714
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18327,11 +20105,11 @@ tr33:
 		}
 		goto tr82
 	st520:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof520
 		}
 	st_case_520:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -18342,12 +20120,12 @@ tr33:
 			goto st521
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18355,11 +20133,11 @@ tr33:
 		}
 		goto tr82
 	st521:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof521
 		}
 	st_case_521:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -18370,12 +20148,12 @@ tr33:
 			goto tr716
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18383,11 +20161,11 @@ tr33:
 		}
 		goto tr82
 	st522:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof522
 		}
 	st_case_522:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -18418,12 +20196,12 @@ tr33:
 			goto st544
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18431,11 +20209,11 @@ tr33:
 		}
 		goto tr82
 	st523:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof523
 		}
 	st_case_523:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 66:
@@ -18446,12 +20224,12 @@ tr33:
 			goto st524
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18459,11 +20237,11 @@ tr33:
 		}
 		goto tr82
 	st524:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof524
 		}
 	st_case_524:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 76:
@@ -18474,12 +20252,12 @@ tr33:
 			goto st525
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18487,11 +20265,11 @@ tr33:
 		}
 		goto tr82
 	st525:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof525
 		}
 	st_case_525:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -18502,12 +20280,12 @@ tr33:
 			goto tr725
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18515,11 +20293,11 @@ tr33:
 		}
 		goto tr82
 	st526:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof526
 		}
 	st_case_526:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -18530,12 +20308,12 @@ tr33:
 			goto st527
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18543,11 +20321,11 @@ tr33:
 		}
 		goto tr82
 	st527:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof527
 		}
 	st_case_527:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -18558,12 +20336,12 @@ tr33:
 			goto tr727
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18571,11 +20349,11 @@ tr33:
 		}
 		goto tr82
 	st528:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof528
 		}
 	st_case_528:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -18586,12 +20364,12 @@ tr33:
 			goto st529
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18599,11 +20377,11 @@ tr33:
 		}
 		goto tr82
 	st529:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof529
 		}
 	st_case_529:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -18614,12 +20392,12 @@ tr33:
 			goto tr729
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18627,11 +20405,11 @@ tr33:
 		}
 		goto tr82
 	st530:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof530
 		}
 	st_case_530:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -18646,12 +20424,12 @@ tr33:
 			goto st539
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18659,11 +20437,11 @@ tr33:
 		}
 		goto tr82
 	st531:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof531
 		}
 	st_case_531:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -18674,12 +20452,12 @@ tr33:
 			goto st532
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18687,11 +20465,11 @@ tr33:
 		}
 		goto tr82
 	st532:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof532
 		}
 	st_case_532:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -18702,12 +20480,12 @@ tr33:
 			goto st533
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18715,11 +20493,11 @@ tr33:
 		}
 		goto tr82
 	st533:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof533
 		}
 	st_case_533:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -18730,12 +20508,12 @@ tr33:
 			goto st534
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18743,11 +20521,11 @@ tr33:
 		}
 		goto tr82
 	st534:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof534
 		}
 	st_case_534:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -18758,12 +20536,12 @@ tr33:
 			goto st535
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18771,11 +20549,11 @@ tr33:
 		}
 		goto tr82
 	st535:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof535
 		}
 	st_case_535:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -18786,12 +20564,12 @@ tr33:
 			goto st536
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18799,11 +20577,11 @@ tr33:
 		}
 		goto tr82
 	st536:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof536
 		}
 	st_case_536:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -18814,12 +20592,12 @@ tr33:
 			goto st537
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18827,11 +20605,11 @@ tr33:
 		}
 		goto tr82
 	st537:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof537
 		}
 	st_case_537:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -18842,12 +20620,12 @@ tr33:
 			goto st538
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18855,11 +20633,11 @@ tr33:
 		}
 		goto tr82
 	st538:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof538
 		}
 	st_case_538:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -18870,12 +20648,12 @@ tr33:
 			goto tr739
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18883,11 +20661,11 @@ tr33:
 		}
 		goto tr82
 	st539:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof539
 		}
 	st_case_539:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -18902,12 +20680,12 @@ tr33:
 			goto st540
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18915,11 +20693,11 @@ tr33:
 		}
 		goto tr82
 	st540:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof540
 		}
 	st_case_540:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -18930,12 +20708,12 @@ tr33:
 			goto st541
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18943,11 +20721,11 @@ tr33:
 		}
 		goto tr82
 	st541:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof541
 		}
 	st_case_541:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -18958,12 +20736,12 @@ tr33:
 			goto st542
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18971,11 +20749,11 @@ tr33:
 		}
 		goto tr82
 	st542:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof542
 		}
 	st_case_542:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -18986,12 +20764,12 @@ tr33:
 			goto st543
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -18999,11 +20777,11 @@ tr33:
 		}
 		goto tr82
 	st543:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof543
 		}
 	st_case_543:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -19014,12 +20792,12 @@ tr33:
 			goto tr745
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19027,11 +20805,11 @@ tr33:
 		}
 		goto tr82
 	st544:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof544
 		}
 	st_case_544:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 80:
@@ -19042,12 +20820,12 @@ tr33:
 			goto st545
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19055,11 +20833,11 @@ tr33:
 		}
 		goto tr82
 	st545:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof545
 		}
 	st_case_545:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -19070,12 +20848,12 @@ tr33:
 			goto tr747
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19083,11 +20861,11 @@ tr33:
 		}
 		goto tr82
 	st546:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof546
 		}
 	st_case_546:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -19106,12 +20884,12 @@ tr33:
 			goto st564
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19119,11 +20897,11 @@ tr33:
 		}
 		goto tr82
 	st547:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof547
 		}
 	st_case_547:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -19138,12 +20916,12 @@ tr33:
 			goto st556
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19151,11 +20929,11 @@ tr33:
 		}
 		goto tr82
 	st548:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof548
 		}
 	st_case_548:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -19166,12 +20944,12 @@ tr33:
 			goto st549
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19179,11 +20957,11 @@ tr33:
 		}
 		goto tr82
 	st549:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof549
 		}
 	st_case_549:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -19194,12 +20972,12 @@ tr33:
 			goto st550
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19207,11 +20985,11 @@ tr33:
 		}
 		goto tr82
 	st550:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof550
 		}
 	st_case_550:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -19222,12 +21000,12 @@ tr33:
 			goto st551
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19235,11 +21013,11 @@ tr33:
 		}
 		goto tr82
 	st551:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof551
 		}
 	st_case_551:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -19250,12 +21028,12 @@ tr33:
 			goto st552
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19263,11 +21041,11 @@ tr33:
 		}
 		goto tr82
 	st552:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof552
 		}
 	st_case_552:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -19278,12 +21056,12 @@ tr33:
 			goto st553
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19291,11 +21069,11 @@ tr33:
 		}
 		goto tr82
 	st553:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof553
 		}
 	st_case_553:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -19306,12 +21084,12 @@ tr33:
 			goto st554
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19319,11 +21097,11 @@ tr33:
 		}
 		goto tr82
 	st554:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof554
 		}
 	st_case_554:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -19334,12 +21112,12 @@ tr33:
 			goto st555
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19347,11 +21125,11 @@ tr33:
 		}
 		goto tr82
 	st555:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof555
 		}
 	st_case_555:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -19362,12 +21140,12 @@ tr33:
 			goto tr760
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19375,11 +21153,11 @@ tr33:
 		}
 		goto tr82
 	st556:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof556
 		}
 	st_case_556:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -19394,12 +21172,12 @@ tr33:
 			goto st558
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19407,11 +21185,11 @@ tr33:
 		}
 		goto tr82
 	st557:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof557
 		}
 	st_case_557:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -19422,12 +21200,12 @@ tr33:
 			goto tr763
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19435,11 +21213,11 @@ tr33:
 		}
 		goto tr82
 	st558:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof558
 		}
 	st_case_558:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -19450,12 +21228,12 @@ tr33:
 			goto st559
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19463,11 +21241,11 @@ tr33:
 		}
 		goto tr82
 	st559:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof559
 		}
 	st_case_559:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -19478,12 +21256,12 @@ tr33:
 			goto tr765
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19491,11 +21269,11 @@ tr33:
 		}
 		goto tr82
 	st560:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof560
 		}
 	st_case_560:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 68:
@@ -19506,12 +21284,12 @@ tr33:
 			goto st561
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19519,11 +21297,11 @@ tr33:
 		}
 		goto tr82
 	st561:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof561
 		}
 	st_case_561:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -19534,12 +21312,12 @@ tr33:
 			goto st562
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19547,11 +21325,11 @@ tr33:
 		}
 		goto tr82
 	st562:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof562
 		}
 	st_case_562:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -19562,12 +21340,12 @@ tr33:
 			goto st563
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19575,11 +21353,11 @@ tr33:
 		}
 		goto tr82
 	st563:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof563
 		}
 	st_case_563:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -19590,12 +21368,12 @@ tr33:
 			goto tr769
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19603,11 +21381,11 @@ tr33:
 		}
 		goto tr82
 	st564:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof564
 		}
 	st_case_564:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -19618,12 +21396,12 @@ tr33:
 			goto st565
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19631,11 +21409,11 @@ tr33:
 		}
 		goto tr82
 	st565:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof565
 		}
 	st_case_565:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -19646,12 +21424,12 @@ tr33:
 			goto st566
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19659,11 +21437,11 @@ tr33:
 		}
 		goto tr82
 	st566:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof566
 		}
 	st_case_566:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 71:
@@ -19674,12 +21452,12 @@ tr33:
 			goto tr772
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19687,11 +21465,11 @@ tr33:
 		}
 		goto tr82
 	st567:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof567
 		}
 	st_case_567:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -19702,12 +21480,12 @@ tr33:
 			goto st568
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19715,11 +21493,11 @@ tr33:
 		}
 		goto tr82
 	st568:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof568
 		}
 	st_case_568:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -19738,12 +21516,12 @@ tr33:
 			goto st575
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19751,11 +21529,11 @@ tr33:
 		}
 		goto tr82
 	st569:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof569
 		}
 	st_case_569:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -19766,12 +21544,12 @@ tr33:
 			goto st570
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19779,11 +21557,11 @@ tr33:
 		}
 		goto tr82
 	st570:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof570
 		}
 	st_case_570:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -19794,12 +21572,12 @@ tr33:
 			goto st571
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19807,11 +21585,11 @@ tr33:
 		}
 		goto tr82
 	st571:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof571
 		}
 	st_case_571:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 77:
@@ -19822,12 +21600,12 @@ tr33:
 			goto tr779
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19835,11 +21613,11 @@ tr33:
 		}
 		goto tr82
 	st572:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof572
 		}
 	st_case_572:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -19850,12 +21628,12 @@ tr33:
 			goto st573
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19863,11 +21641,11 @@ tr33:
 		}
 		goto tr82
 	st573:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof573
 		}
 	st_case_573:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -19878,12 +21656,12 @@ tr33:
 			goto st574
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19891,11 +21669,11 @@ tr33:
 		}
 		goto tr82
 	st574:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof574
 		}
 	st_case_574:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 83:
@@ -19906,12 +21684,12 @@ tr33:
 			goto tr782
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19919,11 +21697,11 @@ tr33:
 		}
 		goto tr82
 	st575:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof575
 		}
 	st_case_575:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 67:
@@ -19934,12 +21712,12 @@ tr33:
 			goto st576
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19947,11 +21725,11 @@ tr33:
 		}
 		goto tr82
 	st576:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof576
 		}
 	st_case_576:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -19962,12 +21740,12 @@ tr33:
 			goto st577
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -19975,11 +21753,11 @@ tr33:
 		}
 		goto tr82
 	st577:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof577
 		}
 	st_case_577:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -19990,12 +21768,12 @@ tr33:
 			goto st578
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20003,11 +21781,11 @@ tr33:
 		}
 		goto tr82
 	st578:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof578
 		}
 	st_case_578:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -20018,12 +21796,12 @@ tr33:
 			goto tr786
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20031,11 +21809,11 @@ tr33:
 		}
 		goto tr82
 	st579:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof579
 		}
 	st_case_579:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -20054,12 +21832,12 @@ tr33:
 			goto st588
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20067,11 +21845,11 @@ tr33:
 		}
 		goto tr82
 	st580:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof580
 		}
 	st_case_580:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -20082,12 +21860,12 @@ tr33:
 			goto st581
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20095,11 +21873,11 @@ tr33:
 		}
 		goto tr82
 	st581:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof581
 		}
 	st_case_581:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -20114,12 +21892,12 @@ tr33:
 			goto st582
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20127,11 +21905,11 @@ tr33:
 		}
 		goto tr82
 	st582:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof582
 		}
 	st_case_582:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -20142,12 +21920,12 @@ tr33:
 			goto tr793
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20155,11 +21933,11 @@ tr33:
 		}
 		goto tr82
 	st583:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof583
 		}
 	st_case_583:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -20170,12 +21948,12 @@ tr33:
 			goto st584
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20183,11 +21961,11 @@ tr33:
 		}
 		goto tr82
 	st584:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof584
 		}
 	st_case_584:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 72:
@@ -20198,12 +21976,12 @@ tr33:
 			goto st585
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20211,11 +21989,11 @@ tr33:
 		}
 		goto tr82
 	st585:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof585
 		}
 	st_case_585:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -20226,12 +22004,12 @@ tr33:
 			goto st586
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20239,11 +22017,11 @@ tr33:
 		}
 		goto tr796
 	st586:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof586
 		}
 	st_case_586:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 85:
@@ -20254,12 +22032,12 @@ tr33:
 			goto st587
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20267,11 +22045,11 @@ tr33:
 		}
 		goto tr82
 	st587:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof587
 		}
 	st_case_587:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -20282,12 +22060,12 @@ tr33:
 			goto tr799
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20295,11 +22073,11 @@ tr33:
 		}
 		goto tr82
 	st588:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof588
 		}
 	st_case_588:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 73:
@@ -20310,12 +22088,12 @@ tr33:
 			goto st589
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20323,11 +22101,11 @@ tr33:
 		}
 		goto tr82
 	st589:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof589
 		}
 	st_case_589:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 84:
@@ -20338,12 +22116,12 @@ tr33:
 			goto st590
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20351,11 +22129,11 @@ tr33:
 		}
 		goto tr82
 	st590:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof590
 		}
 	st_case_590:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -20366,12 +22144,12 @@ tr33:
 			goto tr802
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20379,11 +22157,11 @@ tr33:
 		}
 		goto tr82
 	st591:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof591
 		}
 	st_case_591:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -20394,12 +22172,12 @@ tr33:
 			goto st592
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20407,11 +22185,11 @@ tr33:
 		}
 		goto tr82
 	st592:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof592
 		}
 	st_case_592:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 65:
@@ -20422,12 +22200,12 @@ tr33:
 			goto st593
 		}
 		switch {
-		case  lex.data[( lex.p)] < 66:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 66:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 98 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 98 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20435,11 +22213,11 @@ tr33:
 		}
 		goto tr82
 	st593:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof593
 		}
 	st_case_593:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 82:
@@ -20450,12 +22228,12 @@ tr33:
 			goto tr805
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20463,11 +22241,11 @@ tr33:
 		}
 		goto tr82
 	st594:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof594
 		}
 	st_case_594:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 79:
@@ -20478,12 +22256,12 @@ tr33:
 			goto st595
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20491,11 +22269,11 @@ tr33:
 		}
 		goto tr82
 	st595:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof595
 		}
 	st_case_595:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 78:
@@ -20506,12 +22284,12 @@ tr33:
 			goto st596
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20519,11 +22297,11 @@ tr33:
 		}
 		goto tr82
 	st596:
-		if ( lex.p)++; ( lex.p) == ( lex.pe) {
+		if (lex.p)++; (lex.p) == (lex.pe) {
 			goto _test_eof596
 		}
 	st_case_596:
-		switch  lex.data[( lex.p)] {
+		switch lex.data[(lex.p)] {
 		case 36:
 			goto tr57
 		case 69:
@@ -20534,12 +22312,12 @@ tr33:
 			goto tr808
 		}
 		switch {
-		case  lex.data[( lex.p)] < 65:
-			if 48 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 57 {
+		case lex.data[(lex.p)] < 65:
+			if 48 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 57 {
 				goto tr57
 			}
-		case  lex.data[( lex.p)] > 90:
-			if 97 <=  lex.data[( lex.p)] &&  lex.data[( lex.p)] <= 122 {
+		case lex.data[(lex.p)] > 90:
+			if 97 <= lex.data[(lex.p)] && lex.data[(lex.p)] <= 122 {
 				goto tr57
 			}
 		default:
@@ -20547,1792 +22325,2987 @@ tr33:
 		}
 		goto tr82
 	st_out:
-	_test_eof9:  lex.cs = 9; goto _test_eof
-	_test_eof10:  lex.cs = 10; goto _test_eof
-	_test_eof11:  lex.cs = 11; goto _test_eof
-	_test_eof12:  lex.cs = 12; goto _test_eof
-	_test_eof1:  lex.cs = 1; goto _test_eof
-	_test_eof2:  lex.cs = 2; goto _test_eof
-	_test_eof3:  lex.cs = 3; goto _test_eof
-	_test_eof13:  lex.cs = 13; goto _test_eof
-	_test_eof4:  lex.cs = 4; goto _test_eof
-	_test_eof14:  lex.cs = 14; goto _test_eof
-	_test_eof15:  lex.cs = 15; goto _test_eof
-	_test_eof16:  lex.cs = 16; goto _test_eof
-	_test_eof5:  lex.cs = 5; goto _test_eof
-	_test_eof17:  lex.cs = 17; goto _test_eof
-	_test_eof18:  lex.cs = 18; goto _test_eof
-	_test_eof6:  lex.cs = 6; goto _test_eof
-	_test_eof7:  lex.cs = 7; goto _test_eof
-	_test_eof8:  lex.cs = 8; goto _test_eof
-	_test_eof19:  lex.cs = 19; goto _test_eof
-	_test_eof20:  lex.cs = 20; goto _test_eof
-	_test_eof21:  lex.cs = 21; goto _test_eof
-	_test_eof22:  lex.cs = 22; goto _test_eof
-	_test_eof23:  lex.cs = 23; goto _test_eof
-	_test_eof24:  lex.cs = 24; goto _test_eof
-	_test_eof25:  lex.cs = 25; goto _test_eof
-	_test_eof26:  lex.cs = 26; goto _test_eof
-	_test_eof27:  lex.cs = 27; goto _test_eof
-	_test_eof28:  lex.cs = 28; goto _test_eof
-	_test_eof29:  lex.cs = 29; goto _test_eof
-	_test_eof30:  lex.cs = 30; goto _test_eof
-	_test_eof31:  lex.cs = 31; goto _test_eof
-	_test_eof32:  lex.cs = 32; goto _test_eof
-	_test_eof33:  lex.cs = 33; goto _test_eof
-	_test_eof34:  lex.cs = 34; goto _test_eof
-	_test_eof35:  lex.cs = 35; goto _test_eof
-	_test_eof36:  lex.cs = 36; goto _test_eof
-	_test_eof37:  lex.cs = 37; goto _test_eof
-	_test_eof38:  lex.cs = 38; goto _test_eof
-	_test_eof39:  lex.cs = 39; goto _test_eof
-	_test_eof40:  lex.cs = 40; goto _test_eof
-	_test_eof41:  lex.cs = 41; goto _test_eof
-	_test_eof42:  lex.cs = 42; goto _test_eof
-	_test_eof43:  lex.cs = 43; goto _test_eof
-	_test_eof44:  lex.cs = 44; goto _test_eof
-	_test_eof45:  lex.cs = 45; goto _test_eof
-	_test_eof46:  lex.cs = 46; goto _test_eof
-	_test_eof47:  lex.cs = 47; goto _test_eof
-	_test_eof48:  lex.cs = 48; goto _test_eof
-	_test_eof49:  lex.cs = 49; goto _test_eof
-	_test_eof50:  lex.cs = 50; goto _test_eof
-	_test_eof51:  lex.cs = 51; goto _test_eof
-	_test_eof52:  lex.cs = 52; goto _test_eof
-	_test_eof53:  lex.cs = 53; goto _test_eof
-	_test_eof54:  lex.cs = 54; goto _test_eof
-	_test_eof55:  lex.cs = 55; goto _test_eof
-	_test_eof56:  lex.cs = 56; goto _test_eof
-	_test_eof57:  lex.cs = 57; goto _test_eof
-	_test_eof58:  lex.cs = 58; goto _test_eof
-	_test_eof59:  lex.cs = 59; goto _test_eof
-	_test_eof60:  lex.cs = 60; goto _test_eof
-	_test_eof61:  lex.cs = 61; goto _test_eof
-	_test_eof62:  lex.cs = 62; goto _test_eof
-	_test_eof63:  lex.cs = 63; goto _test_eof
-	_test_eof64:  lex.cs = 64; goto _test_eof
-	_test_eof65:  lex.cs = 65; goto _test_eof
-	_test_eof66:  lex.cs = 66; goto _test_eof
-	_test_eof67:  lex.cs = 67; goto _test_eof
-	_test_eof68:  lex.cs = 68; goto _test_eof
-	_test_eof69:  lex.cs = 69; goto _test_eof
-	_test_eof70:  lex.cs = 70; goto _test_eof
-	_test_eof71:  lex.cs = 71; goto _test_eof
-	_test_eof72:  lex.cs = 72; goto _test_eof
-	_test_eof73:  lex.cs = 73; goto _test_eof
-	_test_eof74:  lex.cs = 74; goto _test_eof
-	_test_eof75:  lex.cs = 75; goto _test_eof
-	_test_eof76:  lex.cs = 76; goto _test_eof
-	_test_eof77:  lex.cs = 77; goto _test_eof
-	_test_eof78:  lex.cs = 78; goto _test_eof
-	_test_eof79:  lex.cs = 79; goto _test_eof
-	_test_eof80:  lex.cs = 80; goto _test_eof
-	_test_eof81:  lex.cs = 81; goto _test_eof
-	_test_eof82:  lex.cs = 82; goto _test_eof
-	_test_eof83:  lex.cs = 83; goto _test_eof
-	_test_eof84:  lex.cs = 84; goto _test_eof
-	_test_eof85:  lex.cs = 85; goto _test_eof
-	_test_eof86:  lex.cs = 86; goto _test_eof
-	_test_eof87:  lex.cs = 87; goto _test_eof
-	_test_eof88:  lex.cs = 88; goto _test_eof
-	_test_eof89:  lex.cs = 89; goto _test_eof
-	_test_eof90:  lex.cs = 90; goto _test_eof
-	_test_eof91:  lex.cs = 91; goto _test_eof
-	_test_eof92:  lex.cs = 92; goto _test_eof
-	_test_eof93:  lex.cs = 93; goto _test_eof
-	_test_eof94:  lex.cs = 94; goto _test_eof
-	_test_eof95:  lex.cs = 95; goto _test_eof
-	_test_eof96:  lex.cs = 96; goto _test_eof
-	_test_eof97:  lex.cs = 97; goto _test_eof
-	_test_eof98:  lex.cs = 98; goto _test_eof
-	_test_eof99:  lex.cs = 99; goto _test_eof
-	_test_eof100:  lex.cs = 100; goto _test_eof
-	_test_eof101:  lex.cs = 101; goto _test_eof
-	_test_eof102:  lex.cs = 102; goto _test_eof
-	_test_eof103:  lex.cs = 103; goto _test_eof
-	_test_eof104:  lex.cs = 104; goto _test_eof
-	_test_eof105:  lex.cs = 105; goto _test_eof
-	_test_eof106:  lex.cs = 106; goto _test_eof
-	_test_eof107:  lex.cs = 107; goto _test_eof
-	_test_eof108:  lex.cs = 108; goto _test_eof
-	_test_eof109:  lex.cs = 109; goto _test_eof
-	_test_eof110:  lex.cs = 110; goto _test_eof
-	_test_eof111:  lex.cs = 111; goto _test_eof
-	_test_eof112:  lex.cs = 112; goto _test_eof
-	_test_eof113:  lex.cs = 113; goto _test_eof
-	_test_eof114:  lex.cs = 114; goto _test_eof
-	_test_eof115:  lex.cs = 115; goto _test_eof
-	_test_eof116:  lex.cs = 116; goto _test_eof
-	_test_eof117:  lex.cs = 117; goto _test_eof
-	_test_eof118:  lex.cs = 118; goto _test_eof
-	_test_eof119:  lex.cs = 119; goto _test_eof
-	_test_eof120:  lex.cs = 120; goto _test_eof
-	_test_eof121:  lex.cs = 121; goto _test_eof
-	_test_eof122:  lex.cs = 122; goto _test_eof
-	_test_eof123:  lex.cs = 123; goto _test_eof
-	_test_eof124:  lex.cs = 124; goto _test_eof
-	_test_eof125:  lex.cs = 125; goto _test_eof
-	_test_eof126:  lex.cs = 126; goto _test_eof
-	_test_eof127:  lex.cs = 127; goto _test_eof
-	_test_eof128:  lex.cs = 128; goto _test_eof
-	_test_eof129:  lex.cs = 129; goto _test_eof
-	_test_eof130:  lex.cs = 130; goto _test_eof
-	_test_eof131:  lex.cs = 131; goto _test_eof
-	_test_eof132:  lex.cs = 132; goto _test_eof
-	_test_eof133:  lex.cs = 133; goto _test_eof
-	_test_eof134:  lex.cs = 134; goto _test_eof
-	_test_eof135:  lex.cs = 135; goto _test_eof
-	_test_eof136:  lex.cs = 136; goto _test_eof
-	_test_eof137:  lex.cs = 137; goto _test_eof
-	_test_eof138:  lex.cs = 138; goto _test_eof
-	_test_eof139:  lex.cs = 139; goto _test_eof
-	_test_eof140:  lex.cs = 140; goto _test_eof
-	_test_eof141:  lex.cs = 141; goto _test_eof
-	_test_eof142:  lex.cs = 142; goto _test_eof
-	_test_eof143:  lex.cs = 143; goto _test_eof
-	_test_eof144:  lex.cs = 144; goto _test_eof
-	_test_eof145:  lex.cs = 145; goto _test_eof
-	_test_eof146:  lex.cs = 146; goto _test_eof
-	_test_eof147:  lex.cs = 147; goto _test_eof
-	_test_eof148:  lex.cs = 148; goto _test_eof
-	_test_eof149:  lex.cs = 149; goto _test_eof
-	_test_eof150:  lex.cs = 150; goto _test_eof
-	_test_eof151:  lex.cs = 151; goto _test_eof
-	_test_eof152:  lex.cs = 152; goto _test_eof
-	_test_eof153:  lex.cs = 153; goto _test_eof
-	_test_eof154:  lex.cs = 154; goto _test_eof
-	_test_eof155:  lex.cs = 155; goto _test_eof
-	_test_eof156:  lex.cs = 156; goto _test_eof
-	_test_eof157:  lex.cs = 157; goto _test_eof
-	_test_eof158:  lex.cs = 158; goto _test_eof
-	_test_eof159:  lex.cs = 159; goto _test_eof
-	_test_eof160:  lex.cs = 160; goto _test_eof
-	_test_eof161:  lex.cs = 161; goto _test_eof
-	_test_eof162:  lex.cs = 162; goto _test_eof
-	_test_eof163:  lex.cs = 163; goto _test_eof
-	_test_eof164:  lex.cs = 164; goto _test_eof
-	_test_eof165:  lex.cs = 165; goto _test_eof
-	_test_eof166:  lex.cs = 166; goto _test_eof
-	_test_eof167:  lex.cs = 167; goto _test_eof
-	_test_eof168:  lex.cs = 168; goto _test_eof
-	_test_eof169:  lex.cs = 169; goto _test_eof
-	_test_eof170:  lex.cs = 170; goto _test_eof
-	_test_eof171:  lex.cs = 171; goto _test_eof
-	_test_eof172:  lex.cs = 172; goto _test_eof
-	_test_eof173:  lex.cs = 173; goto _test_eof
-	_test_eof174:  lex.cs = 174; goto _test_eof
-	_test_eof175:  lex.cs = 175; goto _test_eof
-	_test_eof176:  lex.cs = 176; goto _test_eof
-	_test_eof177:  lex.cs = 177; goto _test_eof
-	_test_eof178:  lex.cs = 178; goto _test_eof
-	_test_eof179:  lex.cs = 179; goto _test_eof
-	_test_eof180:  lex.cs = 180; goto _test_eof
-	_test_eof181:  lex.cs = 181; goto _test_eof
-	_test_eof182:  lex.cs = 182; goto _test_eof
-	_test_eof183:  lex.cs = 183; goto _test_eof
-	_test_eof184:  lex.cs = 184; goto _test_eof
-	_test_eof185:  lex.cs = 185; goto _test_eof
-	_test_eof186:  lex.cs = 186; goto _test_eof
-	_test_eof187:  lex.cs = 187; goto _test_eof
-	_test_eof188:  lex.cs = 188; goto _test_eof
-	_test_eof189:  lex.cs = 189; goto _test_eof
-	_test_eof190:  lex.cs = 190; goto _test_eof
-	_test_eof191:  lex.cs = 191; goto _test_eof
-	_test_eof192:  lex.cs = 192; goto _test_eof
-	_test_eof193:  lex.cs = 193; goto _test_eof
-	_test_eof194:  lex.cs = 194; goto _test_eof
-	_test_eof195:  lex.cs = 195; goto _test_eof
-	_test_eof196:  lex.cs = 196; goto _test_eof
-	_test_eof197:  lex.cs = 197; goto _test_eof
-	_test_eof198:  lex.cs = 198; goto _test_eof
-	_test_eof199:  lex.cs = 199; goto _test_eof
-	_test_eof200:  lex.cs = 200; goto _test_eof
-	_test_eof201:  lex.cs = 201; goto _test_eof
-	_test_eof202:  lex.cs = 202; goto _test_eof
-	_test_eof203:  lex.cs = 203; goto _test_eof
-	_test_eof204:  lex.cs = 204; goto _test_eof
-	_test_eof205:  lex.cs = 205; goto _test_eof
-	_test_eof206:  lex.cs = 206; goto _test_eof
-	_test_eof207:  lex.cs = 207; goto _test_eof
-	_test_eof208:  lex.cs = 208; goto _test_eof
-	_test_eof209:  lex.cs = 209; goto _test_eof
-	_test_eof210:  lex.cs = 210; goto _test_eof
-	_test_eof211:  lex.cs = 211; goto _test_eof
-	_test_eof212:  lex.cs = 212; goto _test_eof
-	_test_eof213:  lex.cs = 213; goto _test_eof
-	_test_eof214:  lex.cs = 214; goto _test_eof
-	_test_eof215:  lex.cs = 215; goto _test_eof
-	_test_eof216:  lex.cs = 216; goto _test_eof
-	_test_eof217:  lex.cs = 217; goto _test_eof
-	_test_eof218:  lex.cs = 218; goto _test_eof
-	_test_eof219:  lex.cs = 219; goto _test_eof
-	_test_eof220:  lex.cs = 220; goto _test_eof
-	_test_eof221:  lex.cs = 221; goto _test_eof
-	_test_eof222:  lex.cs = 222; goto _test_eof
-	_test_eof223:  lex.cs = 223; goto _test_eof
-	_test_eof224:  lex.cs = 224; goto _test_eof
-	_test_eof225:  lex.cs = 225; goto _test_eof
-	_test_eof226:  lex.cs = 226; goto _test_eof
-	_test_eof227:  lex.cs = 227; goto _test_eof
-	_test_eof228:  lex.cs = 228; goto _test_eof
-	_test_eof229:  lex.cs = 229; goto _test_eof
-	_test_eof230:  lex.cs = 230; goto _test_eof
-	_test_eof231:  lex.cs = 231; goto _test_eof
-	_test_eof232:  lex.cs = 232; goto _test_eof
-	_test_eof233:  lex.cs = 233; goto _test_eof
-	_test_eof234:  lex.cs = 234; goto _test_eof
-	_test_eof235:  lex.cs = 235; goto _test_eof
-	_test_eof236:  lex.cs = 236; goto _test_eof
-	_test_eof237:  lex.cs = 237; goto _test_eof
-	_test_eof238:  lex.cs = 238; goto _test_eof
-	_test_eof239:  lex.cs = 239; goto _test_eof
-	_test_eof240:  lex.cs = 240; goto _test_eof
-	_test_eof241:  lex.cs = 241; goto _test_eof
-	_test_eof242:  lex.cs = 242; goto _test_eof
-	_test_eof243:  lex.cs = 243; goto _test_eof
-	_test_eof244:  lex.cs = 244; goto _test_eof
-	_test_eof245:  lex.cs = 245; goto _test_eof
-	_test_eof246:  lex.cs = 246; goto _test_eof
-	_test_eof247:  lex.cs = 247; goto _test_eof
-	_test_eof248:  lex.cs = 248; goto _test_eof
-	_test_eof249:  lex.cs = 249; goto _test_eof
-	_test_eof250:  lex.cs = 250; goto _test_eof
-	_test_eof251:  lex.cs = 251; goto _test_eof
-	_test_eof252:  lex.cs = 252; goto _test_eof
-	_test_eof253:  lex.cs = 253; goto _test_eof
-	_test_eof254:  lex.cs = 254; goto _test_eof
-	_test_eof255:  lex.cs = 255; goto _test_eof
-	_test_eof256:  lex.cs = 256; goto _test_eof
-	_test_eof257:  lex.cs = 257; goto _test_eof
-	_test_eof258:  lex.cs = 258; goto _test_eof
-	_test_eof259:  lex.cs = 259; goto _test_eof
-	_test_eof260:  lex.cs = 260; goto _test_eof
-	_test_eof261:  lex.cs = 261; goto _test_eof
-	_test_eof262:  lex.cs = 262; goto _test_eof
-	_test_eof263:  lex.cs = 263; goto _test_eof
-	_test_eof264:  lex.cs = 264; goto _test_eof
-	_test_eof265:  lex.cs = 265; goto _test_eof
-	_test_eof266:  lex.cs = 266; goto _test_eof
-	_test_eof267:  lex.cs = 267; goto _test_eof
-	_test_eof268:  lex.cs = 268; goto _test_eof
-	_test_eof269:  lex.cs = 269; goto _test_eof
-	_test_eof270:  lex.cs = 270; goto _test_eof
-	_test_eof271:  lex.cs = 271; goto _test_eof
-	_test_eof272:  lex.cs = 272; goto _test_eof
-	_test_eof273:  lex.cs = 273; goto _test_eof
-	_test_eof274:  lex.cs = 274; goto _test_eof
-	_test_eof275:  lex.cs = 275; goto _test_eof
-	_test_eof276:  lex.cs = 276; goto _test_eof
-	_test_eof277:  lex.cs = 277; goto _test_eof
-	_test_eof278:  lex.cs = 278; goto _test_eof
-	_test_eof279:  lex.cs = 279; goto _test_eof
-	_test_eof280:  lex.cs = 280; goto _test_eof
-	_test_eof281:  lex.cs = 281; goto _test_eof
-	_test_eof282:  lex.cs = 282; goto _test_eof
-	_test_eof283:  lex.cs = 283; goto _test_eof
-	_test_eof284:  lex.cs = 284; goto _test_eof
-	_test_eof285:  lex.cs = 285; goto _test_eof
-	_test_eof286:  lex.cs = 286; goto _test_eof
-	_test_eof287:  lex.cs = 287; goto _test_eof
-	_test_eof288:  lex.cs = 288; goto _test_eof
-	_test_eof289:  lex.cs = 289; goto _test_eof
-	_test_eof290:  lex.cs = 290; goto _test_eof
-	_test_eof291:  lex.cs = 291; goto _test_eof
-	_test_eof292:  lex.cs = 292; goto _test_eof
-	_test_eof293:  lex.cs = 293; goto _test_eof
-	_test_eof294:  lex.cs = 294; goto _test_eof
-	_test_eof295:  lex.cs = 295; goto _test_eof
-	_test_eof296:  lex.cs = 296; goto _test_eof
-	_test_eof297:  lex.cs = 297; goto _test_eof
-	_test_eof298:  lex.cs = 298; goto _test_eof
-	_test_eof299:  lex.cs = 299; goto _test_eof
-	_test_eof300:  lex.cs = 300; goto _test_eof
-	_test_eof301:  lex.cs = 301; goto _test_eof
-	_test_eof302:  lex.cs = 302; goto _test_eof
-	_test_eof303:  lex.cs = 303; goto _test_eof
-	_test_eof304:  lex.cs = 304; goto _test_eof
-	_test_eof305:  lex.cs = 305; goto _test_eof
-	_test_eof306:  lex.cs = 306; goto _test_eof
-	_test_eof307:  lex.cs = 307; goto _test_eof
-	_test_eof308:  lex.cs = 308; goto _test_eof
-	_test_eof309:  lex.cs = 309; goto _test_eof
-	_test_eof310:  lex.cs = 310; goto _test_eof
-	_test_eof311:  lex.cs = 311; goto _test_eof
-	_test_eof312:  lex.cs = 312; goto _test_eof
-	_test_eof313:  lex.cs = 313; goto _test_eof
-	_test_eof314:  lex.cs = 314; goto _test_eof
-	_test_eof315:  lex.cs = 315; goto _test_eof
-	_test_eof316:  lex.cs = 316; goto _test_eof
-	_test_eof317:  lex.cs = 317; goto _test_eof
-	_test_eof318:  lex.cs = 318; goto _test_eof
-	_test_eof319:  lex.cs = 319; goto _test_eof
-	_test_eof320:  lex.cs = 320; goto _test_eof
-	_test_eof321:  lex.cs = 321; goto _test_eof
-	_test_eof322:  lex.cs = 322; goto _test_eof
-	_test_eof323:  lex.cs = 323; goto _test_eof
-	_test_eof324:  lex.cs = 324; goto _test_eof
-	_test_eof325:  lex.cs = 325; goto _test_eof
-	_test_eof326:  lex.cs = 326; goto _test_eof
-	_test_eof327:  lex.cs = 327; goto _test_eof
-	_test_eof328:  lex.cs = 328; goto _test_eof
-	_test_eof329:  lex.cs = 329; goto _test_eof
-	_test_eof330:  lex.cs = 330; goto _test_eof
-	_test_eof331:  lex.cs = 331; goto _test_eof
-	_test_eof332:  lex.cs = 332; goto _test_eof
-	_test_eof333:  lex.cs = 333; goto _test_eof
-	_test_eof334:  lex.cs = 334; goto _test_eof
-	_test_eof335:  lex.cs = 335; goto _test_eof
-	_test_eof336:  lex.cs = 336; goto _test_eof
-	_test_eof337:  lex.cs = 337; goto _test_eof
-	_test_eof338:  lex.cs = 338; goto _test_eof
-	_test_eof339:  lex.cs = 339; goto _test_eof
-	_test_eof340:  lex.cs = 340; goto _test_eof
-	_test_eof341:  lex.cs = 341; goto _test_eof
-	_test_eof342:  lex.cs = 342; goto _test_eof
-	_test_eof343:  lex.cs = 343; goto _test_eof
-	_test_eof344:  lex.cs = 344; goto _test_eof
-	_test_eof345:  lex.cs = 345; goto _test_eof
-	_test_eof346:  lex.cs = 346; goto _test_eof
-	_test_eof347:  lex.cs = 347; goto _test_eof
-	_test_eof348:  lex.cs = 348; goto _test_eof
-	_test_eof349:  lex.cs = 349; goto _test_eof
-	_test_eof350:  lex.cs = 350; goto _test_eof
-	_test_eof351:  lex.cs = 351; goto _test_eof
-	_test_eof352:  lex.cs = 352; goto _test_eof
-	_test_eof353:  lex.cs = 353; goto _test_eof
-	_test_eof354:  lex.cs = 354; goto _test_eof
-	_test_eof355:  lex.cs = 355; goto _test_eof
-	_test_eof356:  lex.cs = 356; goto _test_eof
-	_test_eof357:  lex.cs = 357; goto _test_eof
-	_test_eof358:  lex.cs = 358; goto _test_eof
-	_test_eof359:  lex.cs = 359; goto _test_eof
-	_test_eof360:  lex.cs = 360; goto _test_eof
-	_test_eof361:  lex.cs = 361; goto _test_eof
-	_test_eof362:  lex.cs = 362; goto _test_eof
-	_test_eof363:  lex.cs = 363; goto _test_eof
-	_test_eof364:  lex.cs = 364; goto _test_eof
-	_test_eof365:  lex.cs = 365; goto _test_eof
-	_test_eof366:  lex.cs = 366; goto _test_eof
-	_test_eof367:  lex.cs = 367; goto _test_eof
-	_test_eof368:  lex.cs = 368; goto _test_eof
-	_test_eof369:  lex.cs = 369; goto _test_eof
-	_test_eof370:  lex.cs = 370; goto _test_eof
-	_test_eof371:  lex.cs = 371; goto _test_eof
-	_test_eof372:  lex.cs = 372; goto _test_eof
-	_test_eof373:  lex.cs = 373; goto _test_eof
-	_test_eof374:  lex.cs = 374; goto _test_eof
-	_test_eof375:  lex.cs = 375; goto _test_eof
-	_test_eof376:  lex.cs = 376; goto _test_eof
-	_test_eof377:  lex.cs = 377; goto _test_eof
-	_test_eof378:  lex.cs = 378; goto _test_eof
-	_test_eof379:  lex.cs = 379; goto _test_eof
-	_test_eof380:  lex.cs = 380; goto _test_eof
-	_test_eof381:  lex.cs = 381; goto _test_eof
-	_test_eof382:  lex.cs = 382; goto _test_eof
-	_test_eof383:  lex.cs = 383; goto _test_eof
-	_test_eof384:  lex.cs = 384; goto _test_eof
-	_test_eof385:  lex.cs = 385; goto _test_eof
-	_test_eof386:  lex.cs = 386; goto _test_eof
-	_test_eof387:  lex.cs = 387; goto _test_eof
-	_test_eof388:  lex.cs = 388; goto _test_eof
-	_test_eof389:  lex.cs = 389; goto _test_eof
-	_test_eof390:  lex.cs = 390; goto _test_eof
-	_test_eof391:  lex.cs = 391; goto _test_eof
-	_test_eof392:  lex.cs = 392; goto _test_eof
-	_test_eof393:  lex.cs = 393; goto _test_eof
-	_test_eof394:  lex.cs = 394; goto _test_eof
-	_test_eof395:  lex.cs = 395; goto _test_eof
-	_test_eof396:  lex.cs = 396; goto _test_eof
-	_test_eof397:  lex.cs = 397; goto _test_eof
-	_test_eof398:  lex.cs = 398; goto _test_eof
-	_test_eof399:  lex.cs = 399; goto _test_eof
-	_test_eof400:  lex.cs = 400; goto _test_eof
-	_test_eof401:  lex.cs = 401; goto _test_eof
-	_test_eof402:  lex.cs = 402; goto _test_eof
-	_test_eof403:  lex.cs = 403; goto _test_eof
-	_test_eof404:  lex.cs = 404; goto _test_eof
-	_test_eof405:  lex.cs = 405; goto _test_eof
-	_test_eof406:  lex.cs = 406; goto _test_eof
-	_test_eof407:  lex.cs = 407; goto _test_eof
-	_test_eof408:  lex.cs = 408; goto _test_eof
-	_test_eof409:  lex.cs = 409; goto _test_eof
-	_test_eof410:  lex.cs = 410; goto _test_eof
-	_test_eof411:  lex.cs = 411; goto _test_eof
-	_test_eof412:  lex.cs = 412; goto _test_eof
-	_test_eof413:  lex.cs = 413; goto _test_eof
-	_test_eof414:  lex.cs = 414; goto _test_eof
-	_test_eof415:  lex.cs = 415; goto _test_eof
-	_test_eof416:  lex.cs = 416; goto _test_eof
-	_test_eof417:  lex.cs = 417; goto _test_eof
-	_test_eof418:  lex.cs = 418; goto _test_eof
-	_test_eof419:  lex.cs = 419; goto _test_eof
-	_test_eof420:  lex.cs = 420; goto _test_eof
-	_test_eof421:  lex.cs = 421; goto _test_eof
-	_test_eof422:  lex.cs = 422; goto _test_eof
-	_test_eof423:  lex.cs = 423; goto _test_eof
-	_test_eof424:  lex.cs = 424; goto _test_eof
-	_test_eof425:  lex.cs = 425; goto _test_eof
-	_test_eof426:  lex.cs = 426; goto _test_eof
-	_test_eof427:  lex.cs = 427; goto _test_eof
-	_test_eof428:  lex.cs = 428; goto _test_eof
-	_test_eof429:  lex.cs = 429; goto _test_eof
-	_test_eof430:  lex.cs = 430; goto _test_eof
-	_test_eof431:  lex.cs = 431; goto _test_eof
-	_test_eof432:  lex.cs = 432; goto _test_eof
-	_test_eof433:  lex.cs = 433; goto _test_eof
-	_test_eof434:  lex.cs = 434; goto _test_eof
-	_test_eof435:  lex.cs = 435; goto _test_eof
-	_test_eof436:  lex.cs = 436; goto _test_eof
-	_test_eof437:  lex.cs = 437; goto _test_eof
-	_test_eof438:  lex.cs = 438; goto _test_eof
-	_test_eof439:  lex.cs = 439; goto _test_eof
-	_test_eof440:  lex.cs = 440; goto _test_eof
-	_test_eof441:  lex.cs = 441; goto _test_eof
-	_test_eof442:  lex.cs = 442; goto _test_eof
-	_test_eof443:  lex.cs = 443; goto _test_eof
-	_test_eof444:  lex.cs = 444; goto _test_eof
-	_test_eof445:  lex.cs = 445; goto _test_eof
-	_test_eof446:  lex.cs = 446; goto _test_eof
-	_test_eof447:  lex.cs = 447; goto _test_eof
-	_test_eof448:  lex.cs = 448; goto _test_eof
-	_test_eof449:  lex.cs = 449; goto _test_eof
-	_test_eof450:  lex.cs = 450; goto _test_eof
-	_test_eof451:  lex.cs = 451; goto _test_eof
-	_test_eof452:  lex.cs = 452; goto _test_eof
-	_test_eof453:  lex.cs = 453; goto _test_eof
-	_test_eof454:  lex.cs = 454; goto _test_eof
-	_test_eof455:  lex.cs = 455; goto _test_eof
-	_test_eof456:  lex.cs = 456; goto _test_eof
-	_test_eof457:  lex.cs = 457; goto _test_eof
-	_test_eof458:  lex.cs = 458; goto _test_eof
-	_test_eof459:  lex.cs = 459; goto _test_eof
-	_test_eof460:  lex.cs = 460; goto _test_eof
-	_test_eof461:  lex.cs = 461; goto _test_eof
-	_test_eof462:  lex.cs = 462; goto _test_eof
-	_test_eof463:  lex.cs = 463; goto _test_eof
-	_test_eof464:  lex.cs = 464; goto _test_eof
-	_test_eof465:  lex.cs = 465; goto _test_eof
-	_test_eof466:  lex.cs = 466; goto _test_eof
-	_test_eof467:  lex.cs = 467; goto _test_eof
-	_test_eof468:  lex.cs = 468; goto _test_eof
-	_test_eof469:  lex.cs = 469; goto _test_eof
-	_test_eof470:  lex.cs = 470; goto _test_eof
-	_test_eof471:  lex.cs = 471; goto _test_eof
-	_test_eof472:  lex.cs = 472; goto _test_eof
-	_test_eof473:  lex.cs = 473; goto _test_eof
-	_test_eof474:  lex.cs = 474; goto _test_eof
-	_test_eof475:  lex.cs = 475; goto _test_eof
-	_test_eof476:  lex.cs = 476; goto _test_eof
-	_test_eof477:  lex.cs = 477; goto _test_eof
-	_test_eof478:  lex.cs = 478; goto _test_eof
-	_test_eof479:  lex.cs = 479; goto _test_eof
-	_test_eof480:  lex.cs = 480; goto _test_eof
-	_test_eof481:  lex.cs = 481; goto _test_eof
-	_test_eof482:  lex.cs = 482; goto _test_eof
-	_test_eof483:  lex.cs = 483; goto _test_eof
-	_test_eof484:  lex.cs = 484; goto _test_eof
-	_test_eof485:  lex.cs = 485; goto _test_eof
-	_test_eof486:  lex.cs = 486; goto _test_eof
-	_test_eof487:  lex.cs = 487; goto _test_eof
-	_test_eof488:  lex.cs = 488; goto _test_eof
-	_test_eof489:  lex.cs = 489; goto _test_eof
-	_test_eof490:  lex.cs = 490; goto _test_eof
-	_test_eof491:  lex.cs = 491; goto _test_eof
-	_test_eof492:  lex.cs = 492; goto _test_eof
-	_test_eof493:  lex.cs = 493; goto _test_eof
-	_test_eof494:  lex.cs = 494; goto _test_eof
-	_test_eof495:  lex.cs = 495; goto _test_eof
-	_test_eof496:  lex.cs = 496; goto _test_eof
-	_test_eof497:  lex.cs = 497; goto _test_eof
-	_test_eof498:  lex.cs = 498; goto _test_eof
-	_test_eof499:  lex.cs = 499; goto _test_eof
-	_test_eof500:  lex.cs = 500; goto _test_eof
-	_test_eof501:  lex.cs = 501; goto _test_eof
-	_test_eof502:  lex.cs = 502; goto _test_eof
-	_test_eof503:  lex.cs = 503; goto _test_eof
-	_test_eof504:  lex.cs = 504; goto _test_eof
-	_test_eof505:  lex.cs = 505; goto _test_eof
-	_test_eof506:  lex.cs = 506; goto _test_eof
-	_test_eof507:  lex.cs = 507; goto _test_eof
-	_test_eof508:  lex.cs = 508; goto _test_eof
-	_test_eof509:  lex.cs = 509; goto _test_eof
-	_test_eof510:  lex.cs = 510; goto _test_eof
-	_test_eof511:  lex.cs = 511; goto _test_eof
-	_test_eof512:  lex.cs = 512; goto _test_eof
-	_test_eof513:  lex.cs = 513; goto _test_eof
-	_test_eof514:  lex.cs = 514; goto _test_eof
-	_test_eof515:  lex.cs = 515; goto _test_eof
-	_test_eof516:  lex.cs = 516; goto _test_eof
-	_test_eof517:  lex.cs = 517; goto _test_eof
-	_test_eof518:  lex.cs = 518; goto _test_eof
-	_test_eof519:  lex.cs = 519; goto _test_eof
-	_test_eof520:  lex.cs = 520; goto _test_eof
-	_test_eof521:  lex.cs = 521; goto _test_eof
-	_test_eof522:  lex.cs = 522; goto _test_eof
-	_test_eof523:  lex.cs = 523; goto _test_eof
-	_test_eof524:  lex.cs = 524; goto _test_eof
-	_test_eof525:  lex.cs = 525; goto _test_eof
-	_test_eof526:  lex.cs = 526; goto _test_eof
-	_test_eof527:  lex.cs = 527; goto _test_eof
-	_test_eof528:  lex.cs = 528; goto _test_eof
-	_test_eof529:  lex.cs = 529; goto _test_eof
-	_test_eof530:  lex.cs = 530; goto _test_eof
-	_test_eof531:  lex.cs = 531; goto _test_eof
-	_test_eof532:  lex.cs = 532; goto _test_eof
-	_test_eof533:  lex.cs = 533; goto _test_eof
-	_test_eof534:  lex.cs = 534; goto _test_eof
-	_test_eof535:  lex.cs = 535; goto _test_eof
-	_test_eof536:  lex.cs = 536; goto _test_eof
-	_test_eof537:  lex.cs = 537; goto _test_eof
-	_test_eof538:  lex.cs = 538; goto _test_eof
-	_test_eof539:  lex.cs = 539; goto _test_eof
-	_test_eof540:  lex.cs = 540; goto _test_eof
-	_test_eof541:  lex.cs = 541; goto _test_eof
-	_test_eof542:  lex.cs = 542; goto _test_eof
-	_test_eof543:  lex.cs = 543; goto _test_eof
-	_test_eof544:  lex.cs = 544; goto _test_eof
-	_test_eof545:  lex.cs = 545; goto _test_eof
-	_test_eof546:  lex.cs = 546; goto _test_eof
-	_test_eof547:  lex.cs = 547; goto _test_eof
-	_test_eof548:  lex.cs = 548; goto _test_eof
-	_test_eof549:  lex.cs = 549; goto _test_eof
-	_test_eof550:  lex.cs = 550; goto _test_eof
-	_test_eof551:  lex.cs = 551; goto _test_eof
-	_test_eof552:  lex.cs = 552; goto _test_eof
-	_test_eof553:  lex.cs = 553; goto _test_eof
-	_test_eof554:  lex.cs = 554; goto _test_eof
-	_test_eof555:  lex.cs = 555; goto _test_eof
-	_test_eof556:  lex.cs = 556; goto _test_eof
-	_test_eof557:  lex.cs = 557; goto _test_eof
-	_test_eof558:  lex.cs = 558; goto _test_eof
-	_test_eof559:  lex.cs = 559; goto _test_eof
-	_test_eof560:  lex.cs = 560; goto _test_eof
-	_test_eof561:  lex.cs = 561; goto _test_eof
-	_test_eof562:  lex.cs = 562; goto _test_eof
-	_test_eof563:  lex.cs = 563; goto _test_eof
-	_test_eof564:  lex.cs = 564; goto _test_eof
-	_test_eof565:  lex.cs = 565; goto _test_eof
-	_test_eof566:  lex.cs = 566; goto _test_eof
-	_test_eof567:  lex.cs = 567; goto _test_eof
-	_test_eof568:  lex.cs = 568; goto _test_eof
-	_test_eof569:  lex.cs = 569; goto _test_eof
-	_test_eof570:  lex.cs = 570; goto _test_eof
-	_test_eof571:  lex.cs = 571; goto _test_eof
-	_test_eof572:  lex.cs = 572; goto _test_eof
-	_test_eof573:  lex.cs = 573; goto _test_eof
-	_test_eof574:  lex.cs = 574; goto _test_eof
-	_test_eof575:  lex.cs = 575; goto _test_eof
-	_test_eof576:  lex.cs = 576; goto _test_eof
-	_test_eof577:  lex.cs = 577; goto _test_eof
-	_test_eof578:  lex.cs = 578; goto _test_eof
-	_test_eof579:  lex.cs = 579; goto _test_eof
-	_test_eof580:  lex.cs = 580; goto _test_eof
-	_test_eof581:  lex.cs = 581; goto _test_eof
-	_test_eof582:  lex.cs = 582; goto _test_eof
-	_test_eof583:  lex.cs = 583; goto _test_eof
-	_test_eof584:  lex.cs = 584; goto _test_eof
-	_test_eof585:  lex.cs = 585; goto _test_eof
-	_test_eof586:  lex.cs = 586; goto _test_eof
-	_test_eof587:  lex.cs = 587; goto _test_eof
-	_test_eof588:  lex.cs = 588; goto _test_eof
-	_test_eof589:  lex.cs = 589; goto _test_eof
-	_test_eof590:  lex.cs = 590; goto _test_eof
-	_test_eof591:  lex.cs = 591; goto _test_eof
-	_test_eof592:  lex.cs = 592; goto _test_eof
-	_test_eof593:  lex.cs = 593; goto _test_eof
-	_test_eof594:  lex.cs = 594; goto _test_eof
-	_test_eof595:  lex.cs = 595; goto _test_eof
-	_test_eof596:  lex.cs = 596; goto _test_eof
+	_test_eof9:
+		lex.cs = 9
+		goto _test_eof
+	_test_eof10:
+		lex.cs = 10
+		goto _test_eof
+	_test_eof11:
+		lex.cs = 11
+		goto _test_eof
+	_test_eof12:
+		lex.cs = 12
+		goto _test_eof
+	_test_eof1:
+		lex.cs = 1
+		goto _test_eof
+	_test_eof2:
+		lex.cs = 2
+		goto _test_eof
+	_test_eof3:
+		lex.cs = 3
+		goto _test_eof
+	_test_eof13:
+		lex.cs = 13
+		goto _test_eof
+	_test_eof4:
+		lex.cs = 4
+		goto _test_eof
+	_test_eof14:
+		lex.cs = 14
+		goto _test_eof
+	_test_eof15:
+		lex.cs = 15
+		goto _test_eof
+	_test_eof16:
+		lex.cs = 16
+		goto _test_eof
+	_test_eof5:
+		lex.cs = 5
+		goto _test_eof
+	_test_eof17:
+		lex.cs = 17
+		goto _test_eof
+	_test_eof18:
+		lex.cs = 18
+		goto _test_eof
+	_test_eof6:
+		lex.cs = 6
+		goto _test_eof
+	_test_eof7:
+		lex.cs = 7
+		goto _test_eof
+	_test_eof8:
+		lex.cs = 8
+		goto _test_eof
+	_test_eof19:
+		lex.cs = 19
+		goto _test_eof
+	_test_eof20:
+		lex.cs = 20
+		goto _test_eof
+	_test_eof21:
+		lex.cs = 21
+		goto _test_eof
+	_test_eof22:
+		lex.cs = 22
+		goto _test_eof
+	_test_eof23:
+		lex.cs = 23
+		goto _test_eof
+	_test_eof24:
+		lex.cs = 24
+		goto _test_eof
+	_test_eof25:
+		lex.cs = 25
+		goto _test_eof
+	_test_eof26:
+		lex.cs = 26
+		goto _test_eof
+	_test_eof27:
+		lex.cs = 27
+		goto _test_eof
+	_test_eof28:
+		lex.cs = 28
+		goto _test_eof
+	_test_eof29:
+		lex.cs = 29
+		goto _test_eof
+	_test_eof30:
+		lex.cs = 30
+		goto _test_eof
+	_test_eof31:
+		lex.cs = 31
+		goto _test_eof
+	_test_eof32:
+		lex.cs = 32
+		goto _test_eof
+	_test_eof33:
+		lex.cs = 33
+		goto _test_eof
+	_test_eof34:
+		lex.cs = 34
+		goto _test_eof
+	_test_eof35:
+		lex.cs = 35
+		goto _test_eof
+	_test_eof36:
+		lex.cs = 36
+		goto _test_eof
+	_test_eof37:
+		lex.cs = 37
+		goto _test_eof
+	_test_eof38:
+		lex.cs = 38
+		goto _test_eof
+	_test_eof39:
+		lex.cs = 39
+		goto _test_eof
+	_test_eof40:
+		lex.cs = 40
+		goto _test_eof
+	_test_eof41:
+		lex.cs = 41
+		goto _test_eof
+	_test_eof42:
+		lex.cs = 42
+		goto _test_eof
+	_test_eof43:
+		lex.cs = 43
+		goto _test_eof
+	_test_eof44:
+		lex.cs = 44
+		goto _test_eof
+	_test_eof45:
+		lex.cs = 45
+		goto _test_eof
+	_test_eof46:
+		lex.cs = 46
+		goto _test_eof
+	_test_eof47:
+		lex.cs = 47
+		goto _test_eof
+	_test_eof48:
+		lex.cs = 48
+		goto _test_eof
+	_test_eof49:
+		lex.cs = 49
+		goto _test_eof
+	_test_eof50:
+		lex.cs = 50
+		goto _test_eof
+	_test_eof51:
+		lex.cs = 51
+		goto _test_eof
+	_test_eof52:
+		lex.cs = 52
+		goto _test_eof
+	_test_eof53:
+		lex.cs = 53
+		goto _test_eof
+	_test_eof54:
+		lex.cs = 54
+		goto _test_eof
+	_test_eof55:
+		lex.cs = 55
+		goto _test_eof
+	_test_eof56:
+		lex.cs = 56
+		goto _test_eof
+	_test_eof57:
+		lex.cs = 57
+		goto _test_eof
+	_test_eof58:
+		lex.cs = 58
+		goto _test_eof
+	_test_eof59:
+		lex.cs = 59
+		goto _test_eof
+	_test_eof60:
+		lex.cs = 60
+		goto _test_eof
+	_test_eof61:
+		lex.cs = 61
+		goto _test_eof
+	_test_eof62:
+		lex.cs = 62
+		goto _test_eof
+	_test_eof63:
+		lex.cs = 63
+		goto _test_eof
+	_test_eof64:
+		lex.cs = 64
+		goto _test_eof
+	_test_eof65:
+		lex.cs = 65
+		goto _test_eof
+	_test_eof66:
+		lex.cs = 66
+		goto _test_eof
+	_test_eof67:
+		lex.cs = 67
+		goto _test_eof
+	_test_eof68:
+		lex.cs = 68
+		goto _test_eof
+	_test_eof69:
+		lex.cs = 69
+		goto _test_eof
+	_test_eof70:
+		lex.cs = 70
+		goto _test_eof
+	_test_eof71:
+		lex.cs = 71
+		goto _test_eof
+	_test_eof72:
+		lex.cs = 72
+		goto _test_eof
+	_test_eof73:
+		lex.cs = 73
+		goto _test_eof
+	_test_eof74:
+		lex.cs = 74
+		goto _test_eof
+	_test_eof75:
+		lex.cs = 75
+		goto _test_eof
+	_test_eof76:
+		lex.cs = 76
+		goto _test_eof
+	_test_eof77:
+		lex.cs = 77
+		goto _test_eof
+	_test_eof78:
+		lex.cs = 78
+		goto _test_eof
+	_test_eof79:
+		lex.cs = 79
+		goto _test_eof
+	_test_eof80:
+		lex.cs = 80
+		goto _test_eof
+	_test_eof81:
+		lex.cs = 81
+		goto _test_eof
+	_test_eof82:
+		lex.cs = 82
+		goto _test_eof
+	_test_eof83:
+		lex.cs = 83
+		goto _test_eof
+	_test_eof84:
+		lex.cs = 84
+		goto _test_eof
+	_test_eof85:
+		lex.cs = 85
+		goto _test_eof
+	_test_eof86:
+		lex.cs = 86
+		goto _test_eof
+	_test_eof87:
+		lex.cs = 87
+		goto _test_eof
+	_test_eof88:
+		lex.cs = 88
+		goto _test_eof
+	_test_eof89:
+		lex.cs = 89
+		goto _test_eof
+	_test_eof90:
+		lex.cs = 90
+		goto _test_eof
+	_test_eof91:
+		lex.cs = 91
+		goto _test_eof
+	_test_eof92:
+		lex.cs = 92
+		goto _test_eof
+	_test_eof93:
+		lex.cs = 93
+		goto _test_eof
+	_test_eof94:
+		lex.cs = 94
+		goto _test_eof
+	_test_eof95:
+		lex.cs = 95
+		goto _test_eof
+	_test_eof96:
+		lex.cs = 96
+		goto _test_eof
+	_test_eof97:
+		lex.cs = 97
+		goto _test_eof
+	_test_eof98:
+		lex.cs = 98
+		goto _test_eof
+	_test_eof99:
+		lex.cs = 99
+		goto _test_eof
+	_test_eof100:
+		lex.cs = 100
+		goto _test_eof
+	_test_eof101:
+		lex.cs = 101
+		goto _test_eof
+	_test_eof102:
+		lex.cs = 102
+		goto _test_eof
+	_test_eof103:
+		lex.cs = 103
+		goto _test_eof
+	_test_eof104:
+		lex.cs = 104
+		goto _test_eof
+	_test_eof105:
+		lex.cs = 105
+		goto _test_eof
+	_test_eof106:
+		lex.cs = 106
+		goto _test_eof
+	_test_eof107:
+		lex.cs = 107
+		goto _test_eof
+	_test_eof108:
+		lex.cs = 108
+		goto _test_eof
+	_test_eof109:
+		lex.cs = 109
+		goto _test_eof
+	_test_eof110:
+		lex.cs = 110
+		goto _test_eof
+	_test_eof111:
+		lex.cs = 111
+		goto _test_eof
+	_test_eof112:
+		lex.cs = 112
+		goto _test_eof
+	_test_eof113:
+		lex.cs = 113
+		goto _test_eof
+	_test_eof114:
+		lex.cs = 114
+		goto _test_eof
+	_test_eof115:
+		lex.cs = 115
+		goto _test_eof
+	_test_eof116:
+		lex.cs = 116
+		goto _test_eof
+	_test_eof117:
+		lex.cs = 117
+		goto _test_eof
+	_test_eof118:
+		lex.cs = 118
+		goto _test_eof
+	_test_eof119:
+		lex.cs = 119
+		goto _test_eof
+	_test_eof120:
+		lex.cs = 120
+		goto _test_eof
+	_test_eof121:
+		lex.cs = 121
+		goto _test_eof
+	_test_eof122:
+		lex.cs = 122
+		goto _test_eof
+	_test_eof123:
+		lex.cs = 123
+		goto _test_eof
+	_test_eof124:
+		lex.cs = 124
+		goto _test_eof
+	_test_eof125:
+		lex.cs = 125
+		goto _test_eof
+	_test_eof126:
+		lex.cs = 126
+		goto _test_eof
+	_test_eof127:
+		lex.cs = 127
+		goto _test_eof
+	_test_eof128:
+		lex.cs = 128
+		goto _test_eof
+	_test_eof129:
+		lex.cs = 129
+		goto _test_eof
+	_test_eof130:
+		lex.cs = 130
+		goto _test_eof
+	_test_eof131:
+		lex.cs = 131
+		goto _test_eof
+	_test_eof132:
+		lex.cs = 132
+		goto _test_eof
+	_test_eof133:
+		lex.cs = 133
+		goto _test_eof
+	_test_eof134:
+		lex.cs = 134
+		goto _test_eof
+	_test_eof135:
+		lex.cs = 135
+		goto _test_eof
+	_test_eof136:
+		lex.cs = 136
+		goto _test_eof
+	_test_eof137:
+		lex.cs = 137
+		goto _test_eof
+	_test_eof138:
+		lex.cs = 138
+		goto _test_eof
+	_test_eof139:
+		lex.cs = 139
+		goto _test_eof
+	_test_eof140:
+		lex.cs = 140
+		goto _test_eof
+	_test_eof141:
+		lex.cs = 141
+		goto _test_eof
+	_test_eof142:
+		lex.cs = 142
+		goto _test_eof
+	_test_eof143:
+		lex.cs = 143
+		goto _test_eof
+	_test_eof144:
+		lex.cs = 144
+		goto _test_eof
+	_test_eof145:
+		lex.cs = 145
+		goto _test_eof
+	_test_eof146:
+		lex.cs = 146
+		goto _test_eof
+	_test_eof147:
+		lex.cs = 147
+		goto _test_eof
+	_test_eof148:
+		lex.cs = 148
+		goto _test_eof
+	_test_eof149:
+		lex.cs = 149
+		goto _test_eof
+	_test_eof150:
+		lex.cs = 150
+		goto _test_eof
+	_test_eof151:
+		lex.cs = 151
+		goto _test_eof
+	_test_eof152:
+		lex.cs = 152
+		goto _test_eof
+	_test_eof153:
+		lex.cs = 153
+		goto _test_eof
+	_test_eof154:
+		lex.cs = 154
+		goto _test_eof
+	_test_eof155:
+		lex.cs = 155
+		goto _test_eof
+	_test_eof156:
+		lex.cs = 156
+		goto _test_eof
+	_test_eof157:
+		lex.cs = 157
+		goto _test_eof
+	_test_eof158:
+		lex.cs = 158
+		goto _test_eof
+	_test_eof159:
+		lex.cs = 159
+		goto _test_eof
+	_test_eof160:
+		lex.cs = 160
+		goto _test_eof
+	_test_eof161:
+		lex.cs = 161
+		goto _test_eof
+	_test_eof162:
+		lex.cs = 162
+		goto _test_eof
+	_test_eof163:
+		lex.cs = 163
+		goto _test_eof
+	_test_eof164:
+		lex.cs = 164
+		goto _test_eof
+	_test_eof165:
+		lex.cs = 165
+		goto _test_eof
+	_test_eof166:
+		lex.cs = 166
+		goto _test_eof
+	_test_eof167:
+		lex.cs = 167
+		goto _test_eof
+	_test_eof168:
+		lex.cs = 168
+		goto _test_eof
+	_test_eof169:
+		lex.cs = 169
+		goto _test_eof
+	_test_eof170:
+		lex.cs = 170
+		goto _test_eof
+	_test_eof171:
+		lex.cs = 171
+		goto _test_eof
+	_test_eof172:
+		lex.cs = 172
+		goto _test_eof
+	_test_eof173:
+		lex.cs = 173
+		goto _test_eof
+	_test_eof174:
+		lex.cs = 174
+		goto _test_eof
+	_test_eof175:
+		lex.cs = 175
+		goto _test_eof
+	_test_eof176:
+		lex.cs = 176
+		goto _test_eof
+	_test_eof177:
+		lex.cs = 177
+		goto _test_eof
+	_test_eof178:
+		lex.cs = 178
+		goto _test_eof
+	_test_eof179:
+		lex.cs = 179
+		goto _test_eof
+	_test_eof180:
+		lex.cs = 180
+		goto _test_eof
+	_test_eof181:
+		lex.cs = 181
+		goto _test_eof
+	_test_eof182:
+		lex.cs = 182
+		goto _test_eof
+	_test_eof183:
+		lex.cs = 183
+		goto _test_eof
+	_test_eof184:
+		lex.cs = 184
+		goto _test_eof
+	_test_eof185:
+		lex.cs = 185
+		goto _test_eof
+	_test_eof186:
+		lex.cs = 186
+		goto _test_eof
+	_test_eof187:
+		lex.cs = 187
+		goto _test_eof
+	_test_eof188:
+		lex.cs = 188
+		goto _test_eof
+	_test_eof189:
+		lex.cs = 189
+		goto _test_eof
+	_test_eof190:
+		lex.cs = 190
+		goto _test_eof
+	_test_eof191:
+		lex.cs = 191
+		goto _test_eof
+	_test_eof192:
+		lex.cs = 192
+		goto _test_eof
+	_test_eof193:
+		lex.cs = 193
+		goto _test_eof
+	_test_eof194:
+		lex.cs = 194
+		goto _test_eof
+	_test_eof195:
+		lex.cs = 195
+		goto _test_eof
+	_test_eof196:
+		lex.cs = 196
+		goto _test_eof
+	_test_eof197:
+		lex.cs = 197
+		goto _test_eof
+	_test_eof198:
+		lex.cs = 198
+		goto _test_eof
+	_test_eof199:
+		lex.cs = 199
+		goto _test_eof
+	_test_eof200:
+		lex.cs = 200
+		goto _test_eof
+	_test_eof201:
+		lex.cs = 201
+		goto _test_eof
+	_test_eof202:
+		lex.cs = 202
+		goto _test_eof
+	_test_eof203:
+		lex.cs = 203
+		goto _test_eof
+	_test_eof204:
+		lex.cs = 204
+		goto _test_eof
+	_test_eof205:
+		lex.cs = 205
+		goto _test_eof
+	_test_eof206:
+		lex.cs = 206
+		goto _test_eof
+	_test_eof207:
+		lex.cs = 207
+		goto _test_eof
+	_test_eof208:
+		lex.cs = 208
+		goto _test_eof
+	_test_eof209:
+		lex.cs = 209
+		goto _test_eof
+	_test_eof210:
+		lex.cs = 210
+		goto _test_eof
+	_test_eof211:
+		lex.cs = 211
+		goto _test_eof
+	_test_eof212:
+		lex.cs = 212
+		goto _test_eof
+	_test_eof213:
+		lex.cs = 213
+		goto _test_eof
+	_test_eof214:
+		lex.cs = 214
+		goto _test_eof
+	_test_eof215:
+		lex.cs = 215
+		goto _test_eof
+	_test_eof216:
+		lex.cs = 216
+		goto _test_eof
+	_test_eof217:
+		lex.cs = 217
+		goto _test_eof
+	_test_eof218:
+		lex.cs = 218
+		goto _test_eof
+	_test_eof219:
+		lex.cs = 219
+		goto _test_eof
+	_test_eof220:
+		lex.cs = 220
+		goto _test_eof
+	_test_eof221:
+		lex.cs = 221
+		goto _test_eof
+	_test_eof222:
+		lex.cs = 222
+		goto _test_eof
+	_test_eof223:
+		lex.cs = 223
+		goto _test_eof
+	_test_eof224:
+		lex.cs = 224
+		goto _test_eof
+	_test_eof225:
+		lex.cs = 225
+		goto _test_eof
+	_test_eof226:
+		lex.cs = 226
+		goto _test_eof
+	_test_eof227:
+		lex.cs = 227
+		goto _test_eof
+	_test_eof228:
+		lex.cs = 228
+		goto _test_eof
+	_test_eof229:
+		lex.cs = 229
+		goto _test_eof
+	_test_eof230:
+		lex.cs = 230
+		goto _test_eof
+	_test_eof231:
+		lex.cs = 231
+		goto _test_eof
+	_test_eof232:
+		lex.cs = 232
+		goto _test_eof
+	_test_eof233:
+		lex.cs = 233
+		goto _test_eof
+	_test_eof234:
+		lex.cs = 234
+		goto _test_eof
+	_test_eof235:
+		lex.cs = 235
+		goto _test_eof
+	_test_eof236:
+		lex.cs = 236
+		goto _test_eof
+	_test_eof237:
+		lex.cs = 237
+		goto _test_eof
+	_test_eof238:
+		lex.cs = 238
+		goto _test_eof
+	_test_eof239:
+		lex.cs = 239
+		goto _test_eof
+	_test_eof240:
+		lex.cs = 240
+		goto _test_eof
+	_test_eof241:
+		lex.cs = 241
+		goto _test_eof
+	_test_eof242:
+		lex.cs = 242
+		goto _test_eof
+	_test_eof243:
+		lex.cs = 243
+		goto _test_eof
+	_test_eof244:
+		lex.cs = 244
+		goto _test_eof
+	_test_eof245:
+		lex.cs = 245
+		goto _test_eof
+	_test_eof246:
+		lex.cs = 246
+		goto _test_eof
+	_test_eof247:
+		lex.cs = 247
+		goto _test_eof
+	_test_eof248:
+		lex.cs = 248
+		goto _test_eof
+	_test_eof249:
+		lex.cs = 249
+		goto _test_eof
+	_test_eof250:
+		lex.cs = 250
+		goto _test_eof
+	_test_eof251:
+		lex.cs = 251
+		goto _test_eof
+	_test_eof252:
+		lex.cs = 252
+		goto _test_eof
+	_test_eof253:
+		lex.cs = 253
+		goto _test_eof
+	_test_eof254:
+		lex.cs = 254
+		goto _test_eof
+	_test_eof255:
+		lex.cs = 255
+		goto _test_eof
+	_test_eof256:
+		lex.cs = 256
+		goto _test_eof
+	_test_eof257:
+		lex.cs = 257
+		goto _test_eof
+	_test_eof258:
+		lex.cs = 258
+		goto _test_eof
+	_test_eof259:
+		lex.cs = 259
+		goto _test_eof
+	_test_eof260:
+		lex.cs = 260
+		goto _test_eof
+	_test_eof261:
+		lex.cs = 261
+		goto _test_eof
+	_test_eof262:
+		lex.cs = 262
+		goto _test_eof
+	_test_eof263:
+		lex.cs = 263
+		goto _test_eof
+	_test_eof264:
+		lex.cs = 264
+		goto _test_eof
+	_test_eof265:
+		lex.cs = 265
+		goto _test_eof
+	_test_eof266:
+		lex.cs = 266
+		goto _test_eof
+	_test_eof267:
+		lex.cs = 267
+		goto _test_eof
+	_test_eof268:
+		lex.cs = 268
+		goto _test_eof
+	_test_eof269:
+		lex.cs = 269
+		goto _test_eof
+	_test_eof270:
+		lex.cs = 270
+		goto _test_eof
+	_test_eof271:
+		lex.cs = 271
+		goto _test_eof
+	_test_eof272:
+		lex.cs = 272
+		goto _test_eof
+	_test_eof273:
+		lex.cs = 273
+		goto _test_eof
+	_test_eof274:
+		lex.cs = 274
+		goto _test_eof
+	_test_eof275:
+		lex.cs = 275
+		goto _test_eof
+	_test_eof276:
+		lex.cs = 276
+		goto _test_eof
+	_test_eof277:
+		lex.cs = 277
+		goto _test_eof
+	_test_eof278:
+		lex.cs = 278
+		goto _test_eof
+	_test_eof279:
+		lex.cs = 279
+		goto _test_eof
+	_test_eof280:
+		lex.cs = 280
+		goto _test_eof
+	_test_eof281:
+		lex.cs = 281
+		goto _test_eof
+	_test_eof282:
+		lex.cs = 282
+		goto _test_eof
+	_test_eof283:
+		lex.cs = 283
+		goto _test_eof
+	_test_eof284:
+		lex.cs = 284
+		goto _test_eof
+	_test_eof285:
+		lex.cs = 285
+		goto _test_eof
+	_test_eof286:
+		lex.cs = 286
+		goto _test_eof
+	_test_eof287:
+		lex.cs = 287
+		goto _test_eof
+	_test_eof288:
+		lex.cs = 288
+		goto _test_eof
+	_test_eof289:
+		lex.cs = 289
+		goto _test_eof
+	_test_eof290:
+		lex.cs = 290
+		goto _test_eof
+	_test_eof291:
+		lex.cs = 291
+		goto _test_eof
+	_test_eof292:
+		lex.cs = 292
+		goto _test_eof
+	_test_eof293:
+		lex.cs = 293
+		goto _test_eof
+	_test_eof294:
+		lex.cs = 294
+		goto _test_eof
+	_test_eof295:
+		lex.cs = 295
+		goto _test_eof
+	_test_eof296:
+		lex.cs = 296
+		goto _test_eof
+	_test_eof297:
+		lex.cs = 297
+		goto _test_eof
+	_test_eof298:
+		lex.cs = 298
+		goto _test_eof
+	_test_eof299:
+		lex.cs = 299
+		goto _test_eof
+	_test_eof300:
+		lex.cs = 300
+		goto _test_eof
+	_test_eof301:
+		lex.cs = 301
+		goto _test_eof
+	_test_eof302:
+		lex.cs = 302
+		goto _test_eof
+	_test_eof303:
+		lex.cs = 303
+		goto _test_eof
+	_test_eof304:
+		lex.cs = 304
+		goto _test_eof
+	_test_eof305:
+		lex.cs = 305
+		goto _test_eof
+	_test_eof306:
+		lex.cs = 306
+		goto _test_eof
+	_test_eof307:
+		lex.cs = 307
+		goto _test_eof
+	_test_eof308:
+		lex.cs = 308
+		goto _test_eof
+	_test_eof309:
+		lex.cs = 309
+		goto _test_eof
+	_test_eof310:
+		lex.cs = 310
+		goto _test_eof
+	_test_eof311:
+		lex.cs = 311
+		goto _test_eof
+	_test_eof312:
+		lex.cs = 312
+		goto _test_eof
+	_test_eof313:
+		lex.cs = 313
+		goto _test_eof
+	_test_eof314:
+		lex.cs = 314
+		goto _test_eof
+	_test_eof315:
+		lex.cs = 315
+		goto _test_eof
+	_test_eof316:
+		lex.cs = 316
+		goto _test_eof
+	_test_eof317:
+		lex.cs = 317
+		goto _test_eof
+	_test_eof318:
+		lex.cs = 318
+		goto _test_eof
+	_test_eof319:
+		lex.cs = 319
+		goto _test_eof
+	_test_eof320:
+		lex.cs = 320
+		goto _test_eof
+	_test_eof321:
+		lex.cs = 321
+		goto _test_eof
+	_test_eof322:
+		lex.cs = 322
+		goto _test_eof
+	_test_eof323:
+		lex.cs = 323
+		goto _test_eof
+	_test_eof324:
+		lex.cs = 324
+		goto _test_eof
+	_test_eof325:
+		lex.cs = 325
+		goto _test_eof
+	_test_eof326:
+		lex.cs = 326
+		goto _test_eof
+	_test_eof327:
+		lex.cs = 327
+		goto _test_eof
+	_test_eof328:
+		lex.cs = 328
+		goto _test_eof
+	_test_eof329:
+		lex.cs = 329
+		goto _test_eof
+	_test_eof330:
+		lex.cs = 330
+		goto _test_eof
+	_test_eof331:
+		lex.cs = 331
+		goto _test_eof
+	_test_eof332:
+		lex.cs = 332
+		goto _test_eof
+	_test_eof333:
+		lex.cs = 333
+		goto _test_eof
+	_test_eof334:
+		lex.cs = 334
+		goto _test_eof
+	_test_eof335:
+		lex.cs = 335
+		goto _test_eof
+	_test_eof336:
+		lex.cs = 336
+		goto _test_eof
+	_test_eof337:
+		lex.cs = 337
+		goto _test_eof
+	_test_eof338:
+		lex.cs = 338
+		goto _test_eof
+	_test_eof339:
+		lex.cs = 339
+		goto _test_eof
+	_test_eof340:
+		lex.cs = 340
+		goto _test_eof
+	_test_eof341:
+		lex.cs = 341
+		goto _test_eof
+	_test_eof342:
+		lex.cs = 342
+		goto _test_eof
+	_test_eof343:
+		lex.cs = 343
+		goto _test_eof
+	_test_eof344:
+		lex.cs = 344
+		goto _test_eof
+	_test_eof345:
+		lex.cs = 345
+		goto _test_eof
+	_test_eof346:
+		lex.cs = 346
+		goto _test_eof
+	_test_eof347:
+		lex.cs = 347
+		goto _test_eof
+	_test_eof348:
+		lex.cs = 348
+		goto _test_eof
+	_test_eof349:
+		lex.cs = 349
+		goto _test_eof
+	_test_eof350:
+		lex.cs = 350
+		goto _test_eof
+	_test_eof351:
+		lex.cs = 351
+		goto _test_eof
+	_test_eof352:
+		lex.cs = 352
+		goto _test_eof
+	_test_eof353:
+		lex.cs = 353
+		goto _test_eof
+	_test_eof354:
+		lex.cs = 354
+		goto _test_eof
+	_test_eof355:
+		lex.cs = 355
+		goto _test_eof
+	_test_eof356:
+		lex.cs = 356
+		goto _test_eof
+	_test_eof357:
+		lex.cs = 357
+		goto _test_eof
+	_test_eof358:
+		lex.cs = 358
+		goto _test_eof
+	_test_eof359:
+		lex.cs = 359
+		goto _test_eof
+	_test_eof360:
+		lex.cs = 360
+		goto _test_eof
+	_test_eof361:
+		lex.cs = 361
+		goto _test_eof
+	_test_eof362:
+		lex.cs = 362
+		goto _test_eof
+	_test_eof363:
+		lex.cs = 363
+		goto _test_eof
+	_test_eof364:
+		lex.cs = 364
+		goto _test_eof
+	_test_eof365:
+		lex.cs = 365
+		goto _test_eof
+	_test_eof366:
+		lex.cs = 366
+		goto _test_eof
+	_test_eof367:
+		lex.cs = 367
+		goto _test_eof
+	_test_eof368:
+		lex.cs = 368
+		goto _test_eof
+	_test_eof369:
+		lex.cs = 369
+		goto _test_eof
+	_test_eof370:
+		lex.cs = 370
+		goto _test_eof
+	_test_eof371:
+		lex.cs = 371
+		goto _test_eof
+	_test_eof372:
+		lex.cs = 372
+		goto _test_eof
+	_test_eof373:
+		lex.cs = 373
+		goto _test_eof
+	_test_eof374:
+		lex.cs = 374
+		goto _test_eof
+	_test_eof375:
+		lex.cs = 375
+		goto _test_eof
+	_test_eof376:
+		lex.cs = 376
+		goto _test_eof
+	_test_eof377:
+		lex.cs = 377
+		goto _test_eof
+	_test_eof378:
+		lex.cs = 378
+		goto _test_eof
+	_test_eof379:
+		lex.cs = 379
+		goto _test_eof
+	_test_eof380:
+		lex.cs = 380
+		goto _test_eof
+	_test_eof381:
+		lex.cs = 381
+		goto _test_eof
+	_test_eof382:
+		lex.cs = 382
+		goto _test_eof
+	_test_eof383:
+		lex.cs = 383
+		goto _test_eof
+	_test_eof384:
+		lex.cs = 384
+		goto _test_eof
+	_test_eof385:
+		lex.cs = 385
+		goto _test_eof
+	_test_eof386:
+		lex.cs = 386
+		goto _test_eof
+	_test_eof387:
+		lex.cs = 387
+		goto _test_eof
+	_test_eof388:
+		lex.cs = 388
+		goto _test_eof
+	_test_eof389:
+		lex.cs = 389
+		goto _test_eof
+	_test_eof390:
+		lex.cs = 390
+		goto _test_eof
+	_test_eof391:
+		lex.cs = 391
+		goto _test_eof
+	_test_eof392:
+		lex.cs = 392
+		goto _test_eof
+	_test_eof393:
+		lex.cs = 393
+		goto _test_eof
+	_test_eof394:
+		lex.cs = 394
+		goto _test_eof
+	_test_eof395:
+		lex.cs = 395
+		goto _test_eof
+	_test_eof396:
+		lex.cs = 396
+		goto _test_eof
+	_test_eof397:
+		lex.cs = 397
+		goto _test_eof
+	_test_eof398:
+		lex.cs = 398
+		goto _test_eof
+	_test_eof399:
+		lex.cs = 399
+		goto _test_eof
+	_test_eof400:
+		lex.cs = 400
+		goto _test_eof
+	_test_eof401:
+		lex.cs = 401
+		goto _test_eof
+	_test_eof402:
+		lex.cs = 402
+		goto _test_eof
+	_test_eof403:
+		lex.cs = 403
+		goto _test_eof
+	_test_eof404:
+		lex.cs = 404
+		goto _test_eof
+	_test_eof405:
+		lex.cs = 405
+		goto _test_eof
+	_test_eof406:
+		lex.cs = 406
+		goto _test_eof
+	_test_eof407:
+		lex.cs = 407
+		goto _test_eof
+	_test_eof408:
+		lex.cs = 408
+		goto _test_eof
+	_test_eof409:
+		lex.cs = 409
+		goto _test_eof
+	_test_eof410:
+		lex.cs = 410
+		goto _test_eof
+	_test_eof411:
+		lex.cs = 411
+		goto _test_eof
+	_test_eof412:
+		lex.cs = 412
+		goto _test_eof
+	_test_eof413:
+		lex.cs = 413
+		goto _test_eof
+	_test_eof414:
+		lex.cs = 414
+		goto _test_eof
+	_test_eof415:
+		lex.cs = 415
+		goto _test_eof
+	_test_eof416:
+		lex.cs = 416
+		goto _test_eof
+	_test_eof417:
+		lex.cs = 417
+		goto _test_eof
+	_test_eof418:
+		lex.cs = 418
+		goto _test_eof
+	_test_eof419:
+		lex.cs = 419
+		goto _test_eof
+	_test_eof420:
+		lex.cs = 420
+		goto _test_eof
+	_test_eof421:
+		lex.cs = 421
+		goto _test_eof
+	_test_eof422:
+		lex.cs = 422
+		goto _test_eof
+	_test_eof423:
+		lex.cs = 423
+		goto _test_eof
+	_test_eof424:
+		lex.cs = 424
+		goto _test_eof
+	_test_eof425:
+		lex.cs = 425
+		goto _test_eof
+	_test_eof426:
+		lex.cs = 426
+		goto _test_eof
+	_test_eof427:
+		lex.cs = 427
+		goto _test_eof
+	_test_eof428:
+		lex.cs = 428
+		goto _test_eof
+	_test_eof429:
+		lex.cs = 429
+		goto _test_eof
+	_test_eof430:
+		lex.cs = 430
+		goto _test_eof
+	_test_eof431:
+		lex.cs = 431
+		goto _test_eof
+	_test_eof432:
+		lex.cs = 432
+		goto _test_eof
+	_test_eof433:
+		lex.cs = 433
+		goto _test_eof
+	_test_eof434:
+		lex.cs = 434
+		goto _test_eof
+	_test_eof435:
+		lex.cs = 435
+		goto _test_eof
+	_test_eof436:
+		lex.cs = 436
+		goto _test_eof
+	_test_eof437:
+		lex.cs = 437
+		goto _test_eof
+	_test_eof438:
+		lex.cs = 438
+		goto _test_eof
+	_test_eof439:
+		lex.cs = 439
+		goto _test_eof
+	_test_eof440:
+		lex.cs = 440
+		goto _test_eof
+	_test_eof441:
+		lex.cs = 441
+		goto _test_eof
+	_test_eof442:
+		lex.cs = 442
+		goto _test_eof
+	_test_eof443:
+		lex.cs = 443
+		goto _test_eof
+	_test_eof444:
+		lex.cs = 444
+		goto _test_eof
+	_test_eof445:
+		lex.cs = 445
+		goto _test_eof
+	_test_eof446:
+		lex.cs = 446
+		goto _test_eof
+	_test_eof447:
+		lex.cs = 447
+		goto _test_eof
+	_test_eof448:
+		lex.cs = 448
+		goto _test_eof
+	_test_eof449:
+		lex.cs = 449
+		goto _test_eof
+	_test_eof450:
+		lex.cs = 450
+		goto _test_eof
+	_test_eof451:
+		lex.cs = 451
+		goto _test_eof
+	_test_eof452:
+		lex.cs = 452
+		goto _test_eof
+	_test_eof453:
+		lex.cs = 453
+		goto _test_eof
+	_test_eof454:
+		lex.cs = 454
+		goto _test_eof
+	_test_eof455:
+		lex.cs = 455
+		goto _test_eof
+	_test_eof456:
+		lex.cs = 456
+		goto _test_eof
+	_test_eof457:
+		lex.cs = 457
+		goto _test_eof
+	_test_eof458:
+		lex.cs = 458
+		goto _test_eof
+	_test_eof459:
+		lex.cs = 459
+		goto _test_eof
+	_test_eof460:
+		lex.cs = 460
+		goto _test_eof
+	_test_eof461:
+		lex.cs = 461
+		goto _test_eof
+	_test_eof462:
+		lex.cs = 462
+		goto _test_eof
+	_test_eof463:
+		lex.cs = 463
+		goto _test_eof
+	_test_eof464:
+		lex.cs = 464
+		goto _test_eof
+	_test_eof465:
+		lex.cs = 465
+		goto _test_eof
+	_test_eof466:
+		lex.cs = 466
+		goto _test_eof
+	_test_eof467:
+		lex.cs = 467
+		goto _test_eof
+	_test_eof468:
+		lex.cs = 468
+		goto _test_eof
+	_test_eof469:
+		lex.cs = 469
+		goto _test_eof
+	_test_eof470:
+		lex.cs = 470
+		goto _test_eof
+	_test_eof471:
+		lex.cs = 471
+		goto _test_eof
+	_test_eof472:
+		lex.cs = 472
+		goto _test_eof
+	_test_eof473:
+		lex.cs = 473
+		goto _test_eof
+	_test_eof474:
+		lex.cs = 474
+		goto _test_eof
+	_test_eof475:
+		lex.cs = 475
+		goto _test_eof
+	_test_eof476:
+		lex.cs = 476
+		goto _test_eof
+	_test_eof477:
+		lex.cs = 477
+		goto _test_eof
+	_test_eof478:
+		lex.cs = 478
+		goto _test_eof
+	_test_eof479:
+		lex.cs = 479
+		goto _test_eof
+	_test_eof480:
+		lex.cs = 480
+		goto _test_eof
+	_test_eof481:
+		lex.cs = 481
+		goto _test_eof
+	_test_eof482:
+		lex.cs = 482
+		goto _test_eof
+	_test_eof483:
+		lex.cs = 483
+		goto _test_eof
+	_test_eof484:
+		lex.cs = 484
+		goto _test_eof
+	_test_eof485:
+		lex.cs = 485
+		goto _test_eof
+	_test_eof486:
+		lex.cs = 486
+		goto _test_eof
+	_test_eof487:
+		lex.cs = 487
+		goto _test_eof
+	_test_eof488:
+		lex.cs = 488
+		goto _test_eof
+	_test_eof489:
+		lex.cs = 489
+		goto _test_eof
+	_test_eof490:
+		lex.cs = 490
+		goto _test_eof
+	_test_eof491:
+		lex.cs = 491
+		goto _test_eof
+	_test_eof492:
+		lex.cs = 492
+		goto _test_eof
+	_test_eof493:
+		lex.cs = 493
+		goto _test_eof
+	_test_eof494:
+		lex.cs = 494
+		goto _test_eof
+	_test_eof495:
+		lex.cs = 495
+		goto _test_eof
+	_test_eof496:
+		lex.cs = 496
+		goto _test_eof
+	_test_eof497:
+		lex.cs = 497
+		goto _test_eof
+	_test_eof498:
+		lex.cs = 498
+		goto _test_eof
+	_test_eof499:
+		lex.cs = 499
+		goto _test_eof
+	_test_eof500:
+		lex.cs = 500
+		goto _test_eof
+	_test_eof501:
+		lex.cs = 501
+		goto _test_eof
+	_test_eof502:
+		lex.cs = 502
+		goto _test_eof
+	_test_eof503:
+		lex.cs = 503
+		goto _test_eof
+	_test_eof504:
+		lex.cs = 504
+		goto _test_eof
+	_test_eof505:
+		lex.cs = 505
+		goto _test_eof
+	_test_eof506:
+		lex.cs = 506
+		goto _test_eof
+	_test_eof507:
+		lex.cs = 507
+		goto _test_eof
+	_test_eof508:
+		lex.cs = 508
+		goto _test_eof
+	_test_eof509:
+		lex.cs = 509
+		goto _test_eof
+	_test_eof510:
+		lex.cs = 510
+		goto _test_eof
+	_test_eof511:
+		lex.cs = 511
+		goto _test_eof
+	_test_eof512:
+		lex.cs = 512
+		goto _test_eof
+	_test_eof513:
+		lex.cs = 513
+		goto _test_eof
+	_test_eof514:
+		lex.cs = 514
+		goto _test_eof
+	_test_eof515:
+		lex.cs = 515
+		goto _test_eof
+	_test_eof516:
+		lex.cs = 516
+		goto _test_eof
+	_test_eof517:
+		lex.cs = 517
+		goto _test_eof
+	_test_eof518:
+		lex.cs = 518
+		goto _test_eof
+	_test_eof519:
+		lex.cs = 519
+		goto _test_eof
+	_test_eof520:
+		lex.cs = 520
+		goto _test_eof
+	_test_eof521:
+		lex.cs = 521
+		goto _test_eof
+	_test_eof522:
+		lex.cs = 522
+		goto _test_eof
+	_test_eof523:
+		lex.cs = 523
+		goto _test_eof
+	_test_eof524:
+		lex.cs = 524
+		goto _test_eof
+	_test_eof525:
+		lex.cs = 525
+		goto _test_eof
+	_test_eof526:
+		lex.cs = 526
+		goto _test_eof
+	_test_eof527:
+		lex.cs = 527
+		goto _test_eof
+	_test_eof528:
+		lex.cs = 528
+		goto _test_eof
+	_test_eof529:
+		lex.cs = 529
+		goto _test_eof
+	_test_eof530:
+		lex.cs = 530
+		goto _test_eof
+	_test_eof531:
+		lex.cs = 531
+		goto _test_eof
+	_test_eof532:
+		lex.cs = 532
+		goto _test_eof
+	_test_eof533:
+		lex.cs = 533
+		goto _test_eof
+	_test_eof534:
+		lex.cs = 534
+		goto _test_eof
+	_test_eof535:
+		lex.cs = 535
+		goto _test_eof
+	_test_eof536:
+		lex.cs = 536
+		goto _test_eof
+	_test_eof537:
+		lex.cs = 537
+		goto _test_eof
+	_test_eof538:
+		lex.cs = 538
+		goto _test_eof
+	_test_eof539:
+		lex.cs = 539
+		goto _test_eof
+	_test_eof540:
+		lex.cs = 540
+		goto _test_eof
+	_test_eof541:
+		lex.cs = 541
+		goto _test_eof
+	_test_eof542:
+		lex.cs = 542
+		goto _test_eof
+	_test_eof543:
+		lex.cs = 543
+		goto _test_eof
+	_test_eof544:
+		lex.cs = 544
+		goto _test_eof
+	_test_eof545:
+		lex.cs = 545
+		goto _test_eof
+	_test_eof546:
+		lex.cs = 546
+		goto _test_eof
+	_test_eof547:
+		lex.cs = 547
+		goto _test_eof
+	_test_eof548:
+		lex.cs = 548
+		goto _test_eof
+	_test_eof549:
+		lex.cs = 549
+		goto _test_eof
+	_test_eof550:
+		lex.cs = 550
+		goto _test_eof
+	_test_eof551:
+		lex.cs = 551
+		goto _test_eof
+	_test_eof552:
+		lex.cs = 552
+		goto _test_eof
+	_test_eof553:
+		lex.cs = 553
+		goto _test_eof
+	_test_eof554:
+		lex.cs = 554
+		goto _test_eof
+	_test_eof555:
+		lex.cs = 555
+		goto _test_eof
+	_test_eof556:
+		lex.cs = 556
+		goto _test_eof
+	_test_eof557:
+		lex.cs = 557
+		goto _test_eof
+	_test_eof558:
+		lex.cs = 558
+		goto _test_eof
+	_test_eof559:
+		lex.cs = 559
+		goto _test_eof
+	_test_eof560:
+		lex.cs = 560
+		goto _test_eof
+	_test_eof561:
+		lex.cs = 561
+		goto _test_eof
+	_test_eof562:
+		lex.cs = 562
+		goto _test_eof
+	_test_eof563:
+		lex.cs = 563
+		goto _test_eof
+	_test_eof564:
+		lex.cs = 564
+		goto _test_eof
+	_test_eof565:
+		lex.cs = 565
+		goto _test_eof
+	_test_eof566:
+		lex.cs = 566
+		goto _test_eof
+	_test_eof567:
+		lex.cs = 567
+		goto _test_eof
+	_test_eof568:
+		lex.cs = 568
+		goto _test_eof
+	_test_eof569:
+		lex.cs = 569
+		goto _test_eof
+	_test_eof570:
+		lex.cs = 570
+		goto _test_eof
+	_test_eof571:
+		lex.cs = 571
+		goto _test_eof
+	_test_eof572:
+		lex.cs = 572
+		goto _test_eof
+	_test_eof573:
+		lex.cs = 573
+		goto _test_eof
+	_test_eof574:
+		lex.cs = 574
+		goto _test_eof
+	_test_eof575:
+		lex.cs = 575
+		goto _test_eof
+	_test_eof576:
+		lex.cs = 576
+		goto _test_eof
+	_test_eof577:
+		lex.cs = 577
+		goto _test_eof
+	_test_eof578:
+		lex.cs = 578
+		goto _test_eof
+	_test_eof579:
+		lex.cs = 579
+		goto _test_eof
+	_test_eof580:
+		lex.cs = 580
+		goto _test_eof
+	_test_eof581:
+		lex.cs = 581
+		goto _test_eof
+	_test_eof582:
+		lex.cs = 582
+		goto _test_eof
+	_test_eof583:
+		lex.cs = 583
+		goto _test_eof
+	_test_eof584:
+		lex.cs = 584
+		goto _test_eof
+	_test_eof585:
+		lex.cs = 585
+		goto _test_eof
+	_test_eof586:
+		lex.cs = 586
+		goto _test_eof
+	_test_eof587:
+		lex.cs = 587
+		goto _test_eof
+	_test_eof588:
+		lex.cs = 588
+		goto _test_eof
+	_test_eof589:
+		lex.cs = 589
+		goto _test_eof
+	_test_eof590:
+		lex.cs = 590
+		goto _test_eof
+	_test_eof591:
+		lex.cs = 591
+		goto _test_eof
+	_test_eof592:
+		lex.cs = 592
+		goto _test_eof
+	_test_eof593:
+		lex.cs = 593
+		goto _test_eof
+	_test_eof594:
+		lex.cs = 594
+		goto _test_eof
+	_test_eof595:
+		lex.cs = 595
+		goto _test_eof
+	_test_eof596:
+		lex.cs = 596
+		goto _test_eof
 
-	_test_eof: {}
-	if ( lex.p) == eof {
-		switch  lex.cs {
-		case 10:
-			goto tr63
-		case 11:
-			goto tr64
-		case 12:
-			goto tr0
-		case 1:
-			goto tr0
-		case 13:
-			goto tr66
-		case 14:
-			goto tr67
-		case 15:
-			goto tr71
-		case 16:
-			goto tr71
-		case 5:
-			goto tr9
-		case 17:
-			goto tr0
-		case 18:
-			goto tr73
-		case 19:
-			goto tr74
-		case 20:
-			goto tr0
-		case 21:
-			goto tr74
-		case 22:
-			goto tr75
-		case 23:
-			goto tr77
-		case 24:
-			goto tr80
-		case 25:
-			goto tr82
-		case 26:
-			goto tr82
-		case 27:
-			goto tr82
-		case 28:
-			goto tr82
-		case 29:
-			goto tr82
-		case 30:
-			goto tr82
-		case 31:
-			goto tr82
-		case 32:
-			goto tr82
-		case 33:
-			goto tr82
-		case 34:
-			goto tr82
-		case 35:
-			goto tr82
-		case 36:
-			goto tr82
-		case 37:
-			goto tr82
-		case 38:
-			goto tr82
-		case 39:
-			goto tr82
-		case 40:
-			goto tr105
-		case 41:
-			goto tr82
-		case 42:
-			goto tr82
-		case 43:
-			goto tr82
-		case 44:
-			goto tr82
-		case 45:
-			goto tr82
-		case 46:
-			goto tr82
-		case 47:
-			goto tr82
-		case 48:
-			goto tr82
-		case 49:
-			goto tr82
-		case 50:
-			goto tr82
-		case 51:
-			goto tr82
-		case 52:
-			goto tr82
-		case 53:
-			goto tr82
-		case 54:
-			goto tr82
-		case 55:
-			goto tr82
-		case 56:
-			goto tr82
-		case 57:
-			goto tr82
-		case 58:
-			goto tr82
-		case 59:
-			goto tr82
-		case 60:
-			goto tr82
-		case 61:
-			goto tr82
-		case 62:
-			goto tr82
-		case 63:
-			goto tr82
-		case 64:
-			goto tr82
-		case 65:
-			goto tr82
-		case 66:
-			goto tr82
-		case 67:
-			goto tr82
-		case 68:
-			goto tr82
-		case 69:
-			goto tr82
-		case 70:
-			goto tr82
-		case 71:
-			goto tr82
-		case 72:
-			goto tr82
-		case 73:
-			goto tr82
-		case 74:
-			goto tr82
-		case 75:
-			goto tr82
-		case 76:
-			goto tr82
-		case 77:
-			goto tr82
-		case 78:
-			goto tr82
-		case 79:
-			goto tr82
-		case 80:
-			goto tr82
-		case 81:
-			goto tr165
-		case 82:
-			goto tr82
-		case 83:
-			goto tr82
-		case 84:
-			goto tr82
-		case 85:
-			goto tr82
-		case 86:
-			goto tr171
-		case 87:
-			goto tr82
-		case 88:
-			goto tr82
-		case 89:
-			goto tr82
-		case 90:
-			goto tr82
-		case 91:
-			goto tr82
-		case 92:
-			goto tr82
-		case 93:
-			goto tr82
-		case 94:
-			goto tr82
-		case 95:
-			goto tr82
-		case 96:
-			goto tr82
-		case 97:
-			goto tr82
-		case 98:
-			goto tr82
-		case 99:
-			goto tr82
-		case 100:
-			goto tr82
-		case 101:
-			goto tr82
-		case 102:
-			goto tr82
-		case 103:
-			goto tr191
-		case 104:
-			goto tr82
-		case 105:
-			goto tr82
-		case 106:
-			goto tr82
-		case 107:
-			goto tr82
-		case 108:
-			goto tr82
-		case 109:
-			goto tr82
-		case 110:
-			goto tr82
-		case 111:
-			goto tr82
-		case 112:
-			goto tr82
-		case 113:
-			goto tr82
-		case 114:
-			goto tr82
-		case 115:
-			goto tr82
-		case 116:
-			goto tr82
-		case 117:
-			goto tr82
-		case 118:
-			goto tr82
-		case 119:
-			goto tr82
-		case 120:
-			goto tr82
-		case 121:
-			goto tr82
-		case 122:
-			goto tr82
-		case 123:
-			goto tr82
-		case 124:
-			goto tr82
-		case 125:
-			goto tr82
-		case 126:
-			goto tr82
-		case 127:
-			goto tr82
-		case 128:
-			goto tr82
-		case 129:
-			goto tr82
-		case 130:
-			goto tr82
-		case 131:
-			goto tr82
-		case 132:
-			goto tr82
-		case 133:
-			goto tr82
-		case 134:
-			goto tr82
-		case 135:
-			goto tr82
-		case 136:
-			goto tr82
-		case 137:
-			goto tr82
-		case 138:
-			goto tr82
-		case 139:
-			goto tr82
-		case 140:
-			goto tr82
-		case 141:
-			goto tr82
-		case 142:
-			goto tr82
-		case 143:
-			goto tr82
-		case 144:
-			goto tr82
-		case 145:
-			goto tr82
-		case 146:
-			goto tr82
-		case 147:
-			goto tr82
-		case 148:
-			goto tr82
-		case 149:
-			goto tr82
-		case 150:
-			goto tr82
-		case 151:
-			goto tr82
-		case 152:
-			goto tr82
-		case 153:
-			goto tr254
-		case 154:
-			goto tr82
-		case 155:
-			goto tr82
-		case 156:
-			goto tr82
-		case 157:
-			goto tr82
-		case 158:
-			goto tr82
-		case 159:
-			goto tr82
-		case 160:
-			goto tr82
-		case 161:
-			goto tr82
-		case 162:
-			goto tr82
-		case 163:
-			goto tr82
-		case 164:
-			goto tr82
-		case 165:
-			goto tr82
-		case 166:
-			goto tr82
-		case 167:
-			goto tr82
-		case 168:
-			goto tr82
-		case 169:
-			goto tr82
-		case 170:
-			goto tr82
-		case 171:
-			goto tr82
-		case 172:
-			goto tr82
-		case 173:
-			goto tr82
-		case 174:
-			goto tr82
-		case 175:
-			goto tr279
-		case 176:
-			goto tr82
-		case 177:
-			goto tr82
-		case 178:
-			goto tr82
-		case 179:
-			goto tr82
-		case 180:
-			goto tr82
-		case 181:
-			goto tr82
-		case 182:
-			goto tr82
-		case 183:
-			goto tr82
-		case 184:
-			goto tr82
-		case 185:
-			goto tr82
-		case 186:
-			goto tr82
-		case 187:
-			goto tr82
-		case 188:
-			goto tr294
-		case 189:
-			goto tr82
-		case 190:
-			goto tr82
-		case 191:
-			goto tr82
-		case 192:
-			goto tr82
-		case 193:
-			goto tr82
-		case 194:
-			goto tr82
-		case 195:
-			goto tr82
-		case 196:
-			goto tr82
-		case 197:
-			goto tr82
-		case 198:
-			goto tr82
-		case 199:
-			goto tr82
-		case 200:
-			goto tr82
-		case 201:
-			goto tr82
-		case 202:
-			goto tr82
-		case 203:
-			goto tr82
-		case 204:
-			goto tr82
-		case 205:
-			goto tr82
-		case 206:
-			goto tr82
-		case 207:
-			goto tr82
-		case 208:
-			goto tr82
-		case 209:
-			goto tr82
-		case 210:
-			goto tr82
-		case 211:
-			goto tr82
-		case 212:
-			goto tr82
-		case 213:
-			goto tr82
-		case 214:
-			goto tr82
-		case 215:
-			goto tr82
-		case 216:
-			goto tr82
-		case 217:
-			goto tr82
-		case 218:
-			goto tr82
-		case 219:
-			goto tr82
-		case 220:
-			goto tr82
-		case 221:
-			goto tr82
-		case 222:
-			goto tr82
-		case 223:
-			goto tr82
-		case 224:
-			goto tr82
-		case 225:
-			goto tr82
-		case 226:
-			goto tr82
-		case 227:
-			goto tr82
-		case 228:
-			goto tr82
-		case 229:
-			goto tr82
-		case 230:
-			goto tr82
-		case 231:
-			goto tr82
-		case 232:
-			goto tr82
-		case 233:
-			goto tr82
-		case 234:
-			goto tr82
-		case 235:
-			goto tr82
-		case 236:
-			goto tr82
-		case 237:
-			goto tr82
-		case 238:
-			goto tr82
-		case 239:
-			goto tr82
-		case 240:
-			goto tr82
-		case 241:
-			goto tr82
-		case 242:
-			goto tr82
-		case 243:
-			goto tr82
-		case 244:
-			goto tr82
-		case 245:
-			goto tr82
-		case 246:
-			goto tr369
-		case 247:
-			goto tr82
-		case 248:
-			goto tr82
-		case 249:
-			goto tr82
-		case 250:
-			goto tr82
-		case 251:
-			goto tr82
-		case 252:
-			goto tr82
-		case 253:
-			goto tr82
-		case 254:
-			goto tr82
-		case 255:
-			goto tr82
-		case 256:
-			goto tr82
-		case 257:
-			goto tr82
-		case 258:
-			goto tr82
-		case 259:
-			goto tr82
-		case 260:
-			goto tr82
-		case 261:
-			goto tr82
-		case 262:
-			goto tr82
-		case 263:
-			goto tr82
-		case 264:
-			goto tr82
-		case 265:
-			goto tr82
-		case 266:
-			goto tr82
-		case 267:
-			goto tr82
-		case 268:
-			goto tr82
-		case 269:
-			goto tr82
-		case 270:
-			goto tr82
-		case 271:
-			goto tr82
-		case 272:
-			goto tr82
-		case 273:
-			goto tr82
-		case 274:
-			goto tr82
-		case 275:
-			goto tr405
-		case 276:
-			goto tr82
-		case 277:
-			goto tr82
-		case 278:
-			goto tr82
-		case 279:
-			goto tr82
-		case 280:
-			goto tr82
-		case 281:
-			goto tr82
-		case 282:
-			goto tr82
-		case 283:
-			goto tr417
-		case 284:
-			goto tr82
-		case 285:
-			goto tr82
-		case 286:
-			goto tr82
-		case 287:
-			goto tr82
-		case 288:
-			goto tr82
-		case 289:
-			goto tr82
-		case 290:
-			goto tr82
-		case 291:
-			goto tr82
-		case 292:
-			goto tr82
-		case 293:
-			goto tr431
-		case 294:
-			goto tr82
-		case 295:
-			goto tr82
-		case 296:
-			goto tr82
-		case 297:
-			goto tr82
-		case 298:
-			goto tr82
-		case 299:
-			goto tr82
-		case 300:
-			goto tr82
-		case 301:
-			goto tr82
-		case 302:
-			goto tr82
-		case 303:
-			goto tr82
-		case 304:
-			goto tr82
-		case 305:
-			goto tr82
-		case 306:
-			goto tr82
-		case 307:
-			goto tr82
-		case 308:
-			goto tr82
-		case 309:
-			goto tr82
-		case 310:
-			goto tr82
-		case 311:
-			goto tr82
-		case 312:
-			goto tr82
-		case 313:
-			goto tr82
-		case 314:
-			goto tr82
-		case 315:
-			goto tr82
-		case 316:
-			goto tr82
-		case 317:
-			goto tr82
-		case 318:
-			goto tr82
-		case 319:
-			goto tr82
-		case 320:
-			goto tr82
-		case 321:
-			goto tr82
-		case 322:
-			goto tr82
-		case 323:
-			goto tr82
-		case 324:
-			goto tr82
-		case 325:
-			goto tr82
-		case 326:
-			goto tr82
-		case 327:
-			goto tr82
-		case 328:
-			goto tr82
-		case 329:
-			goto tr82
-		case 330:
-			goto tr82
-		case 331:
-			goto tr82
-		case 332:
-			goto tr82
-		case 333:
-			goto tr82
-		case 334:
-			goto tr82
-		case 335:
-			goto tr82
-		case 336:
-			goto tr82
-		case 337:
-			goto tr82
-		case 338:
-			goto tr82
-		case 339:
-			goto tr82
-		case 340:
-			goto tr82
-		case 341:
-			goto tr82
-		case 342:
-			goto tr82
-		case 343:
-			goto tr82
-		case 344:
-			goto tr82
-		case 345:
-			goto tr82
-		case 346:
-			goto tr82
-		case 347:
-			goto tr82
-		case 348:
-			goto tr82
-		case 349:
-			goto tr82
-		case 350:
-			goto tr82
-		case 351:
-			goto tr82
-		case 352:
-			goto tr82
-		case 353:
-			goto tr505
-		case 354:
-			goto tr82
-		case 355:
-			goto tr82
-		case 356:
-			goto tr82
-		case 357:
-			goto tr82
-		case 358:
-			goto tr82
-		case 359:
-			goto tr82
-		case 360:
-			goto tr82
-		case 361:
-			goto tr82
-		case 362:
-			goto tr517
-		case 363:
-			goto tr82
-		case 364:
-			goto tr82
-		case 365:
-			goto tr82
-		case 366:
-			goto tr82
-		case 367:
-			goto tr82
-		case 368:
-			goto tr527
-		case 369:
-			goto tr82
-		case 370:
-			goto tr82
-		case 371:
-			goto tr82
-		case 372:
-			goto tr532
-		case 373:
-			goto tr82
-		case 374:
-			goto tr535
-		case 375:
-			goto tr82
-		case 376:
-			goto tr82
-		case 377:
-			goto tr82
-		case 378:
-			goto tr82
-		case 379:
-			goto tr82
-		case 380:
-			goto tr82
-		case 381:
-			goto tr82
-		case 382:
-			goto tr82
-		case 383:
-			goto tr82
-		case 384:
-			goto tr82
-		case 385:
-			goto tr82
-		case 386:
-			goto tr82
-		case 387:
-			goto tr82
-		case 388:
-			goto tr82
-		case 389:
-			goto tr82
-		case 390:
-			goto tr82
-		case 391:
-			goto tr82
-		case 392:
-			goto tr82
-		case 393:
-			goto tr82
-		case 394:
-			goto tr82
-		case 395:
-			goto tr82
-		case 396:
-			goto tr82
-		case 397:
-			goto tr82
-		case 398:
-			goto tr82
-		case 399:
-			goto tr82
-		case 400:
-			goto tr82
-		case 401:
-			goto tr82
-		case 402:
-			goto tr82
-		case 403:
-			goto tr82
-		case 404:
-			goto tr82
-		case 405:
-			goto tr82
-		case 406:
-			goto tr82
-		case 407:
-			goto tr82
-		case 408:
-			goto tr82
-		case 409:
-			goto tr82
-		case 410:
-			goto tr82
-		case 411:
-			goto tr82
-		case 412:
-			goto tr82
-		case 413:
-			goto tr82
-		case 414:
-			goto tr82
-		case 415:
-			goto tr82
-		case 416:
-			goto tr82
-		case 417:
-			goto tr82
-		case 418:
-			goto tr82
-		case 419:
-			goto tr82
-		case 420:
-			goto tr82
-		case 421:
-			goto tr82
-		case 422:
-			goto tr82
-		case 423:
-			goto tr82
-		case 424:
-			goto tr82
-		case 425:
-			goto tr82
-		case 426:
-			goto tr82
-		case 427:
-			goto tr82
-		case 428:
-			goto tr82
-		case 429:
-			goto tr82
-		case 430:
-			goto tr82
-		case 431:
-			goto tr82
-		case 432:
-			goto tr82
-		case 433:
-			goto tr82
-		case 434:
-			goto tr82
-		case 435:
-			goto tr82
-		case 436:
-			goto tr82
-		case 437:
-			goto tr82
-		case 438:
-			goto tr82
-		case 439:
-			goto tr82
-		case 440:
-			goto tr82
-		case 441:
-			goto tr82
-		case 442:
-			goto tr82
-		case 443:
-			goto tr82
-		case 444:
-			goto tr82
-		case 445:
-			goto tr82
-		case 446:
-			goto tr82
-		case 447:
-			goto tr82
-		case 448:
-			goto tr82
-		case 449:
-			goto tr82
-		case 450:
-			goto tr82
-		case 451:
-			goto tr82
-		case 452:
-			goto tr82
-		case 453:
-			goto tr82
-		case 454:
-			goto tr82
-		case 455:
-			goto tr82
-		case 456:
-			goto tr82
-		case 457:
-			goto tr82
-		case 458:
-			goto tr82
-		case 459:
-			goto tr82
-		case 460:
-			goto tr82
-		case 461:
-			goto tr82
-		case 462:
-			goto tr82
-		case 463:
-			goto tr82
-		case 464:
-			goto tr82
-		case 465:
-			goto tr82
-		case 466:
-			goto tr82
-		case 467:
-			goto tr82
-		case 468:
-			goto tr82
-		case 469:
-			goto tr82
-		case 470:
-			goto tr82
-		case 471:
-			goto tr82
-		case 472:
-			goto tr82
-		case 473:
-			goto tr82
-		case 474:
-			goto tr82
-		case 475:
-			goto tr82
-		case 476:
-			goto tr82
-		case 477:
-			goto tr82
-		case 478:
-			goto tr82
-		case 479:
-			goto tr82
-		case 480:
-			goto tr82
-		case 481:
-			goto tr82
-		case 482:
-			goto tr82
-		case 483:
-			goto tr82
-		case 484:
-			goto tr82
-		case 485:
-			goto tr82
-		case 486:
-			goto tr82
-		case 487:
-			goto tr82
-		case 488:
-			goto tr82
-		case 489:
-			goto tr82
-		case 490:
-			goto tr82
-		case 491:
-			goto tr82
-		case 492:
-			goto tr82
-		case 493:
-			goto tr82
-		case 494:
-			goto tr82
-		case 495:
-			goto tr685
-		case 496:
-			goto tr82
-		case 497:
-			goto tr82
-		case 498:
-			goto tr82
-		case 499:
-			goto tr82
-		case 500:
-			goto tr82
-		case 501:
-			goto tr82
-		case 502:
-			goto tr82
-		case 503:
-			goto tr82
-		case 504:
-			goto tr82
-		case 505:
-			goto tr82
-		case 506:
-			goto tr82
-		case 507:
-			goto tr82
-		case 508:
-			goto tr82
-		case 509:
-			goto tr82
-		case 510:
-			goto tr82
-		case 511:
-			goto tr82
-		case 512:
-			goto tr82
-		case 513:
-			goto tr82
-		case 514:
-			goto tr82
-		case 515:
-			goto tr82
-		case 516:
-			goto tr82
-		case 517:
-			goto tr82
-		case 518:
-			goto tr82
-		case 519:
-			goto tr82
-		case 520:
-			goto tr82
-		case 521:
-			goto tr82
-		case 522:
-			goto tr82
-		case 523:
-			goto tr82
-		case 524:
-			goto tr82
-		case 525:
-			goto tr82
-		case 526:
-			goto tr82
-		case 527:
-			goto tr82
-		case 528:
-			goto tr82
-		case 529:
-			goto tr82
-		case 530:
-			goto tr82
-		case 531:
-			goto tr82
-		case 532:
-			goto tr82
-		case 533:
-			goto tr82
-		case 534:
-			goto tr82
-		case 535:
-			goto tr82
-		case 536:
-			goto tr82
-		case 537:
-			goto tr82
-		case 538:
-			goto tr82
-		case 539:
-			goto tr82
-		case 540:
-			goto tr82
-		case 541:
-			goto tr82
-		case 542:
-			goto tr82
-		case 543:
-			goto tr82
-		case 544:
-			goto tr82
-		case 545:
-			goto tr82
-		case 546:
-			goto tr82
-		case 547:
-			goto tr82
-		case 548:
-			goto tr82
-		case 549:
-			goto tr82
-		case 550:
-			goto tr82
-		case 551:
-			goto tr82
-		case 552:
-			goto tr82
-		case 553:
-			goto tr82
-		case 554:
-			goto tr82
-		case 555:
-			goto tr82
-		case 556:
-			goto tr82
-		case 557:
-			goto tr82
-		case 558:
-			goto tr82
-		case 559:
-			goto tr82
-		case 560:
-			goto tr82
-		case 561:
-			goto tr82
-		case 562:
-			goto tr82
-		case 563:
-			goto tr82
-		case 564:
-			goto tr82
-		case 565:
-			goto tr82
-		case 566:
-			goto tr82
-		case 567:
-			goto tr82
-		case 568:
-			goto tr82
-		case 569:
-			goto tr82
-		case 570:
-			goto tr82
-		case 571:
-			goto tr82
-		case 572:
-			goto tr82
-		case 573:
-			goto tr82
-		case 574:
-			goto tr82
-		case 575:
-			goto tr82
-		case 576:
-			goto tr82
-		case 577:
-			goto tr82
-		case 578:
-			goto tr82
-		case 579:
-			goto tr82
-		case 580:
-			goto tr82
-		case 581:
-			goto tr82
-		case 582:
-			goto tr82
-		case 583:
-			goto tr82
-		case 584:
-			goto tr82
-		case 585:
-			goto tr796
-		case 586:
-			goto tr82
-		case 587:
-			goto tr82
-		case 588:
-			goto tr82
-		case 589:
-			goto tr82
-		case 590:
-			goto tr82
-		case 591:
-			goto tr82
-		case 592:
-			goto tr82
-		case 593:
-			goto tr82
-		case 594:
-			goto tr82
-		case 595:
-			goto tr82
-		case 596:
-			goto tr82
+	_test_eof:
+		{
 		}
-	}
+		if (lex.p) == eof {
+			switch lex.cs {
+			case 10:
+				goto tr63
+			case 11:
+				goto tr64
+			case 12:
+				goto tr0
+			case 1:
+				goto tr0
+			case 13:
+				goto tr66
+			case 14:
+				goto tr67
+			case 15:
+				goto tr71
+			case 16:
+				goto tr71
+			case 5:
+				goto tr9
+			case 17:
+				goto tr0
+			case 18:
+				goto tr73
+			case 19:
+				goto tr74
+			case 20:
+				goto tr0
+			case 21:
+				goto tr74
+			case 22:
+				goto tr75
+			case 23:
+				goto tr77
+			case 24:
+				goto tr80
+			case 25:
+				goto tr82
+			case 26:
+				goto tr82
+			case 27:
+				goto tr82
+			case 28:
+				goto tr82
+			case 29:
+				goto tr82
+			case 30:
+				goto tr82
+			case 31:
+				goto tr82
+			case 32:
+				goto tr82
+			case 33:
+				goto tr82
+			case 34:
+				goto tr82
+			case 35:
+				goto tr82
+			case 36:
+				goto tr82
+			case 37:
+				goto tr82
+			case 38:
+				goto tr82
+			case 39:
+				goto tr82
+			case 40:
+				goto tr105
+			case 41:
+				goto tr82
+			case 42:
+				goto tr82
+			case 43:
+				goto tr82
+			case 44:
+				goto tr82
+			case 45:
+				goto tr82
+			case 46:
+				goto tr82
+			case 47:
+				goto tr82
+			case 48:
+				goto tr82
+			case 49:
+				goto tr82
+			case 50:
+				goto tr82
+			case 51:
+				goto tr82
+			case 52:
+				goto tr82
+			case 53:
+				goto tr82
+			case 54:
+				goto tr82
+			case 55:
+				goto tr82
+			case 56:
+				goto tr82
+			case 57:
+				goto tr82
+			case 58:
+				goto tr82
+			case 59:
+				goto tr82
+			case 60:
+				goto tr82
+			case 61:
+				goto tr82
+			case 62:
+				goto tr82
+			case 63:
+				goto tr82
+			case 64:
+				goto tr82
+			case 65:
+				goto tr82
+			case 66:
+				goto tr82
+			case 67:
+				goto tr82
+			case 68:
+				goto tr82
+			case 69:
+				goto tr82
+			case 70:
+				goto tr82
+			case 71:
+				goto tr82
+			case 72:
+				goto tr82
+			case 73:
+				goto tr82
+			case 74:
+				goto tr82
+			case 75:
+				goto tr82
+			case 76:
+				goto tr82
+			case 77:
+				goto tr82
+			case 78:
+				goto tr82
+			case 79:
+				goto tr82
+			case 80:
+				goto tr82
+			case 81:
+				goto tr165
+			case 82:
+				goto tr82
+			case 83:
+				goto tr82
+			case 84:
+				goto tr82
+			case 85:
+				goto tr82
+			case 86:
+				goto tr171
+			case 87:
+				goto tr82
+			case 88:
+				goto tr82
+			case 89:
+				goto tr82
+			case 90:
+				goto tr82
+			case 91:
+				goto tr82
+			case 92:
+				goto tr82
+			case 93:
+				goto tr82
+			case 94:
+				goto tr82
+			case 95:
+				goto tr82
+			case 96:
+				goto tr82
+			case 97:
+				goto tr82
+			case 98:
+				goto tr82
+			case 99:
+				goto tr82
+			case 100:
+				goto tr82
+			case 101:
+				goto tr82
+			case 102:
+				goto tr82
+			case 103:
+				goto tr191
+			case 104:
+				goto tr82
+			case 105:
+				goto tr82
+			case 106:
+				goto tr82
+			case 107:
+				goto tr82
+			case 108:
+				goto tr82
+			case 109:
+				goto tr82
+			case 110:
+				goto tr82
+			case 111:
+				goto tr82
+			case 112:
+				goto tr82
+			case 113:
+				goto tr82
+			case 114:
+				goto tr82
+			case 115:
+				goto tr82
+			case 116:
+				goto tr82
+			case 117:
+				goto tr82
+			case 118:
+				goto tr82
+			case 119:
+				goto tr82
+			case 120:
+				goto tr82
+			case 121:
+				goto tr82
+			case 122:
+				goto tr82
+			case 123:
+				goto tr82
+			case 124:
+				goto tr82
+			case 125:
+				goto tr82
+			case 126:
+				goto tr82
+			case 127:
+				goto tr82
+			case 128:
+				goto tr82
+			case 129:
+				goto tr82
+			case 130:
+				goto tr82
+			case 131:
+				goto tr82
+			case 132:
+				goto tr82
+			case 133:
+				goto tr82
+			case 134:
+				goto tr82
+			case 135:
+				goto tr82
+			case 136:
+				goto tr82
+			case 137:
+				goto tr82
+			case 138:
+				goto tr82
+			case 139:
+				goto tr82
+			case 140:
+				goto tr82
+			case 141:
+				goto tr82
+			case 142:
+				goto tr82
+			case 143:
+				goto tr82
+			case 144:
+				goto tr82
+			case 145:
+				goto tr82
+			case 146:
+				goto tr82
+			case 147:
+				goto tr82
+			case 148:
+				goto tr82
+			case 149:
+				goto tr82
+			case 150:
+				goto tr82
+			case 151:
+				goto tr82
+			case 152:
+				goto tr82
+			case 153:
+				goto tr254
+			case 154:
+				goto tr82
+			case 155:
+				goto tr82
+			case 156:
+				goto tr82
+			case 157:
+				goto tr82
+			case 158:
+				goto tr82
+			case 159:
+				goto tr82
+			case 160:
+				goto tr82
+			case 161:
+				goto tr82
+			case 162:
+				goto tr82
+			case 163:
+				goto tr82
+			case 164:
+				goto tr82
+			case 165:
+				goto tr82
+			case 166:
+				goto tr82
+			case 167:
+				goto tr82
+			case 168:
+				goto tr82
+			case 169:
+				goto tr82
+			case 170:
+				goto tr82
+			case 171:
+				goto tr82
+			case 172:
+				goto tr82
+			case 173:
+				goto tr82
+			case 174:
+				goto tr82
+			case 175:
+				goto tr279
+			case 176:
+				goto tr82
+			case 177:
+				goto tr82
+			case 178:
+				goto tr82
+			case 179:
+				goto tr82
+			case 180:
+				goto tr82
+			case 181:
+				goto tr82
+			case 182:
+				goto tr82
+			case 183:
+				goto tr82
+			case 184:
+				goto tr82
+			case 185:
+				goto tr82
+			case 186:
+				goto tr82
+			case 187:
+				goto tr82
+			case 188:
+				goto tr294
+			case 189:
+				goto tr82
+			case 190:
+				goto tr82
+			case 191:
+				goto tr82
+			case 192:
+				goto tr82
+			case 193:
+				goto tr82
+			case 194:
+				goto tr82
+			case 195:
+				goto tr82
+			case 196:
+				goto tr82
+			case 197:
+				goto tr82
+			case 198:
+				goto tr82
+			case 199:
+				goto tr82
+			case 200:
+				goto tr82
+			case 201:
+				goto tr82
+			case 202:
+				goto tr82
+			case 203:
+				goto tr82
+			case 204:
+				goto tr82
+			case 205:
+				goto tr82
+			case 206:
+				goto tr82
+			case 207:
+				goto tr82
+			case 208:
+				goto tr82
+			case 209:
+				goto tr82
+			case 210:
+				goto tr82
+			case 211:
+				goto tr82
+			case 212:
+				goto tr82
+			case 213:
+				goto tr82
+			case 214:
+				goto tr82
+			case 215:
+				goto tr82
+			case 216:
+				goto tr82
+			case 217:
+				goto tr82
+			case 218:
+				goto tr82
+			case 219:
+				goto tr82
+			case 220:
+				goto tr82
+			case 221:
+				goto tr82
+			case 222:
+				goto tr82
+			case 223:
+				goto tr82
+			case 224:
+				goto tr82
+			case 225:
+				goto tr82
+			case 226:
+				goto tr82
+			case 227:
+				goto tr82
+			case 228:
+				goto tr82
+			case 229:
+				goto tr82
+			case 230:
+				goto tr82
+			case 231:
+				goto tr82
+			case 232:
+				goto tr82
+			case 233:
+				goto tr82
+			case 234:
+				goto tr82
+			case 235:
+				goto tr82
+			case 236:
+				goto tr82
+			case 237:
+				goto tr82
+			case 238:
+				goto tr82
+			case 239:
+				goto tr82
+			case 240:
+				goto tr82
+			case 241:
+				goto tr82
+			case 242:
+				goto tr82
+			case 243:
+				goto tr82
+			case 244:
+				goto tr82
+			case 245:
+				goto tr82
+			case 246:
+				goto tr369
+			case 247:
+				goto tr82
+			case 248:
+				goto tr82
+			case 249:
+				goto tr82
+			case 250:
+				goto tr82
+			case 251:
+				goto tr82
+			case 252:
+				goto tr82
+			case 253:
+				goto tr82
+			case 254:
+				goto tr82
+			case 255:
+				goto tr82
+			case 256:
+				goto tr82
+			case 257:
+				goto tr82
+			case 258:
+				goto tr82
+			case 259:
+				goto tr82
+			case 260:
+				goto tr82
+			case 261:
+				goto tr82
+			case 262:
+				goto tr82
+			case 263:
+				goto tr82
+			case 264:
+				goto tr82
+			case 265:
+				goto tr82
+			case 266:
+				goto tr82
+			case 267:
+				goto tr82
+			case 268:
+				goto tr82
+			case 269:
+				goto tr82
+			case 270:
+				goto tr82
+			case 271:
+				goto tr82
+			case 272:
+				goto tr82
+			case 273:
+				goto tr82
+			case 274:
+				goto tr82
+			case 275:
+				goto tr405
+			case 276:
+				goto tr82
+			case 277:
+				goto tr82
+			case 278:
+				goto tr82
+			case 279:
+				goto tr82
+			case 280:
+				goto tr82
+			case 281:
+				goto tr82
+			case 282:
+				goto tr82
+			case 283:
+				goto tr417
+			case 284:
+				goto tr82
+			case 285:
+				goto tr82
+			case 286:
+				goto tr82
+			case 287:
+				goto tr82
+			case 288:
+				goto tr82
+			case 289:
+				goto tr82
+			case 290:
+				goto tr82
+			case 291:
+				goto tr82
+			case 292:
+				goto tr82
+			case 293:
+				goto tr431
+			case 294:
+				goto tr82
+			case 295:
+				goto tr82
+			case 296:
+				goto tr82
+			case 297:
+				goto tr82
+			case 298:
+				goto tr82
+			case 299:
+				goto tr82
+			case 300:
+				goto tr82
+			case 301:
+				goto tr82
+			case 302:
+				goto tr82
+			case 303:
+				goto tr82
+			case 304:
+				goto tr82
+			case 305:
+				goto tr82
+			case 306:
+				goto tr82
+			case 307:
+				goto tr82
+			case 308:
+				goto tr82
+			case 309:
+				goto tr82
+			case 310:
+				goto tr82
+			case 311:
+				goto tr82
+			case 312:
+				goto tr82
+			case 313:
+				goto tr82
+			case 314:
+				goto tr82
+			case 315:
+				goto tr82
+			case 316:
+				goto tr82
+			case 317:
+				goto tr82
+			case 318:
+				goto tr82
+			case 319:
+				goto tr82
+			case 320:
+				goto tr82
+			case 321:
+				goto tr82
+			case 322:
+				goto tr82
+			case 323:
+				goto tr82
+			case 324:
+				goto tr82
+			case 325:
+				goto tr82
+			case 326:
+				goto tr82
+			case 327:
+				goto tr82
+			case 328:
+				goto tr82
+			case 329:
+				goto tr82
+			case 330:
+				goto tr82
+			case 331:
+				goto tr82
+			case 332:
+				goto tr82
+			case 333:
+				goto tr82
+			case 334:
+				goto tr82
+			case 335:
+				goto tr82
+			case 336:
+				goto tr82
+			case 337:
+				goto tr82
+			case 338:
+				goto tr82
+			case 339:
+				goto tr82
+			case 340:
+				goto tr82
+			case 341:
+				goto tr82
+			case 342:
+				goto tr82
+			case 343:
+				goto tr82
+			case 344:
+				goto tr82
+			case 345:
+				goto tr82
+			case 346:
+				goto tr82
+			case 347:
+				goto tr82
+			case 348:
+				goto tr82
+			case 349:
+				goto tr82
+			case 350:
+				goto tr82
+			case 351:
+				goto tr82
+			case 352:
+				goto tr82
+			case 353:
+				goto tr505
+			case 354:
+				goto tr82
+			case 355:
+				goto tr82
+			case 356:
+				goto tr82
+			case 357:
+				goto tr82
+			case 358:
+				goto tr82
+			case 359:
+				goto tr82
+			case 360:
+				goto tr82
+			case 361:
+				goto tr82
+			case 362:
+				goto tr517
+			case 363:
+				goto tr82
+			case 364:
+				goto tr82
+			case 365:
+				goto tr82
+			case 366:
+				goto tr82
+			case 367:
+				goto tr82
+			case 368:
+				goto tr527
+			case 369:
+				goto tr82
+			case 370:
+				goto tr82
+			case 371:
+				goto tr82
+			case 372:
+				goto tr532
+			case 373:
+				goto tr82
+			case 374:
+				goto tr535
+			case 375:
+				goto tr82
+			case 376:
+				goto tr82
+			case 377:
+				goto tr82
+			case 378:
+				goto tr82
+			case 379:
+				goto tr82
+			case 380:
+				goto tr82
+			case 381:
+				goto tr82
+			case 382:
+				goto tr82
+			case 383:
+				goto tr82
+			case 384:
+				goto tr82
+			case 385:
+				goto tr82
+			case 386:
+				goto tr82
+			case 387:
+				goto tr82
+			case 388:
+				goto tr82
+			case 389:
+				goto tr82
+			case 390:
+				goto tr82
+			case 391:
+				goto tr82
+			case 392:
+				goto tr82
+			case 393:
+				goto tr82
+			case 394:
+				goto tr82
+			case 395:
+				goto tr82
+			case 396:
+				goto tr82
+			case 397:
+				goto tr82
+			case 398:
+				goto tr82
+			case 399:
+				goto tr82
+			case 400:
+				goto tr82
+			case 401:
+				goto tr82
+			case 402:
+				goto tr82
+			case 403:
+				goto tr82
+			case 404:
+				goto tr82
+			case 405:
+				goto tr82
+			case 406:
+				goto tr82
+			case 407:
+				goto tr82
+			case 408:
+				goto tr82
+			case 409:
+				goto tr82
+			case 410:
+				goto tr82
+			case 411:
+				goto tr82
+			case 412:
+				goto tr82
+			case 413:
+				goto tr82
+			case 414:
+				goto tr82
+			case 415:
+				goto tr82
+			case 416:
+				goto tr82
+			case 417:
+				goto tr82
+			case 418:
+				goto tr82
+			case 419:
+				goto tr82
+			case 420:
+				goto tr82
+			case 421:
+				goto tr82
+			case 422:
+				goto tr82
+			case 423:
+				goto tr82
+			case 424:
+				goto tr82
+			case 425:
+				goto tr82
+			case 426:
+				goto tr82
+			case 427:
+				goto tr82
+			case 428:
+				goto tr82
+			case 429:
+				goto tr82
+			case 430:
+				goto tr82
+			case 431:
+				goto tr82
+			case 432:
+				goto tr82
+			case 433:
+				goto tr82
+			case 434:
+				goto tr82
+			case 435:
+				goto tr82
+			case 436:
+				goto tr82
+			case 437:
+				goto tr82
+			case 438:
+				goto tr82
+			case 439:
+				goto tr82
+			case 440:
+				goto tr82
+			case 441:
+				goto tr82
+			case 442:
+				goto tr82
+			case 443:
+				goto tr82
+			case 444:
+				goto tr82
+			case 445:
+				goto tr82
+			case 446:
+				goto tr82
+			case 447:
+				goto tr82
+			case 448:
+				goto tr82
+			case 449:
+				goto tr82
+			case 450:
+				goto tr82
+			case 451:
+				goto tr82
+			case 452:
+				goto tr82
+			case 453:
+				goto tr82
+			case 454:
+				goto tr82
+			case 455:
+				goto tr82
+			case 456:
+				goto tr82
+			case 457:
+				goto tr82
+			case 458:
+				goto tr82
+			case 459:
+				goto tr82
+			case 460:
+				goto tr82
+			case 461:
+				goto tr82
+			case 462:
+				goto tr82
+			case 463:
+				goto tr82
+			case 464:
+				goto tr82
+			case 465:
+				goto tr82
+			case 466:
+				goto tr82
+			case 467:
+				goto tr82
+			case 468:
+				goto tr82
+			case 469:
+				goto tr82
+			case 470:
+				goto tr82
+			case 471:
+				goto tr82
+			case 472:
+				goto tr82
+			case 473:
+				goto tr82
+			case 474:
+				goto tr82
+			case 475:
+				goto tr82
+			case 476:
+				goto tr82
+			case 477:
+				goto tr82
+			case 478:
+				goto tr82
+			case 479:
+				goto tr82
+			case 480:
+				goto tr82
+			case 481:
+				goto tr82
+			case 482:
+				goto tr82
+			case 483:
+				goto tr82
+			case 484:
+				goto tr82
+			case 485:
+				goto tr82
+			case 486:
+				goto tr82
+			case 487:
+				goto tr82
+			case 488:
+				goto tr82
+			case 489:
+				goto tr82
+			case 490:
+				goto tr82
+			case 491:
+				goto tr82
+			case 492:
+				goto tr82
+			case 493:
+				goto tr82
+			case 494:
+				goto tr82
+			case 495:
+				goto tr685
+			case 496:
+				goto tr82
+			case 497:
+				goto tr82
+			case 498:
+				goto tr82
+			case 499:
+				goto tr82
+			case 500:
+				goto tr82
+			case 501:
+				goto tr82
+			case 502:
+				goto tr82
+			case 503:
+				goto tr82
+			case 504:
+				goto tr82
+			case 505:
+				goto tr82
+			case 506:
+				goto tr82
+			case 507:
+				goto tr82
+			case 508:
+				goto tr82
+			case 509:
+				goto tr82
+			case 510:
+				goto tr82
+			case 511:
+				goto tr82
+			case 512:
+				goto tr82
+			case 513:
+				goto tr82
+			case 514:
+				goto tr82
+			case 515:
+				goto tr82
+			case 516:
+				goto tr82
+			case 517:
+				goto tr82
+			case 518:
+				goto tr82
+			case 519:
+				goto tr82
+			case 520:
+				goto tr82
+			case 521:
+				goto tr82
+			case 522:
+				goto tr82
+			case 523:
+				goto tr82
+			case 524:
+				goto tr82
+			case 525:
+				goto tr82
+			case 526:
+				goto tr82
+			case 527:
+				goto tr82
+			case 528:
+				goto tr82
+			case 529:
+				goto tr82
+			case 530:
+				goto tr82
+			case 531:
+				goto tr82
+			case 532:
+				goto tr82
+			case 533:
+				goto tr82
+			case 534:
+				goto tr82
+			case 535:
+				goto tr82
+			case 536:
+				goto tr82
+			case 537:
+				goto tr82
+			case 538:
+				goto tr82
+			case 539:
+				goto tr82
+			case 540:
+				goto tr82
+			case 541:
+				goto tr82
+			case 542:
+				goto tr82
+			case 543:
+				goto tr82
+			case 544:
+				goto tr82
+			case 545:
+				goto tr82
+			case 546:
+				goto tr82
+			case 547:
+				goto tr82
+			case 548:
+				goto tr82
+			case 549:
+				goto tr82
+			case 550:
+				goto tr82
+			case 551:
+				goto tr82
+			case 552:
+				goto tr82
+			case 553:
+				goto tr82
+			case 554:
+				goto tr82
+			case 555:
+				goto tr82
+			case 556:
+				goto tr82
+			case 557:
+				goto tr82
+			case 558:
+				goto tr82
+			case 559:
+				goto tr82
+			case 560:
+				goto tr82
+			case 561:
+				goto tr82
+			case 562:
+				goto tr82
+			case 563:
+				goto tr82
+			case 564:
+				goto tr82
+			case 565:
+				goto tr82
+			case 566:
+				goto tr82
+			case 567:
+				goto tr82
+			case 568:
+				goto tr82
+			case 569:
+				goto tr82
+			case 570:
+				goto tr82
+			case 571:
+				goto tr82
+			case 572:
+				goto tr82
+			case 573:
+				goto tr82
+			case 574:
+				goto tr82
+			case 575:
+				goto tr82
+			case 576:
+				goto tr82
+			case 577:
+				goto tr82
+			case 578:
+				goto tr82
+			case 579:
+				goto tr82
+			case 580:
+				goto tr82
+			case 581:
+				goto tr82
+			case 582:
+				goto tr82
+			case 583:
+				goto tr82
+			case 584:
+				goto tr82
+			case 585:
+				goto tr796
+			case 586:
+				goto tr82
+			case 587:
+				goto tr82
+			case 588:
+				goto tr82
+			case 589:
+				goto tr82
+			case 590:
+				goto tr82
+			case 591:
+				goto tr82
+			case 592:
+				goto tr82
+			case 593:
+				goto tr82
+			case 594:
+				goto tr82
+			case 595:
+				goto tr82
+			case 596:
+				goto tr82
+			}
+		}
 
-	_out: {}
+	_out:
+		{
+		}
 	}
 
 //line lyx/lexer.rl:408
 
-
-    return int(tok);
+	return int(tok)
 }

--- a/lyx/sconst_test.go
+++ b/lyx/sconst_test.go
@@ -1,0 +1,24 @@
+package lyx_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pg-sharding/lyx/lyx"
+)
+
+func TestParseHandlesEscapedSingleQuotes(t *testing.T) {
+	query := "SELECT 'value'';still''inside';"
+
+	stmts, err := lyx.Parse(query)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	selectStmt, ok := stmts[0].(*lyx.Select)
+	require.True(t, ok)
+
+	literal, ok := selectStmt.TargetList[0].(*lyx.AExprSConst)
+	require.True(t, ok)
+	require.Equal(t, "value';still'inside", literal.Value)
+}


### PR DESCRIPTION
## Summary
- preprocess lexer input to replace doubled single quotes with placeholders so the Ragel scanner no longer terminates a string literal early, and unescape the placeholders when emitting `SCONST` tokens
- add a regression test that parses a `SELECT` with escaped single quotes to prove the lexer accepts embedded quotes and semicolons inside literals

## Testing
- `make test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173747a028832db2d7d9b0ee45ea5c)